### PR TITLE
chore(env): add .env-example template for local development

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,8 +1,21 @@
-#	JWT
+# JWT ─ Wird fuer die Erstellung und Validierung von JSON Web Tokens verwendet
+# Dieser Wert muss in der Anwendung korrekt geladen werden
 JWT_SECRET=...
 
-#	DB
-DB_HOST=...
-DB_NAME=...
-DB_USER=...
-DB_PASS=...
+# PHP-Anwendung (Backend/API) ─ Verbindung zur Datenbank
+DB_HOST=db					# Muss dem Namen des DB-Containers ensprechen (siehe docker-compose.yml, unter Services)
+DB_NAME=WebStart			# Muss mit MARIADB_DATABASE uebereinstimmen
+DB_USER=...					# Muss mit MARIADB_USER uebereinstimmen
+DB_PASS=...					# Muss mit MARIADB_PASSWORD uebereinstimmen
+DB_CHARSET=utf8mb4			# Zeichensatz fuer die Verbindung (im Projekt genuzt: utf8mb4)
+
+# MariaDB ─ Initialisierung beim ersten Start
+MARIADB_DATABASE=WebStart	# Erstellt diese Datenbank beim ersten Start
+MARIADB_USER=...			# Datenbankbenutzer (muss mit DB_USER uebereinstimmen)
+MARIADB_PASSWORD=...		# Benutzerpasswort (muss mit DB_PASS uebereinstimmen)
+MARIADB_ROOT_PASSWORD=...	# Root-Zugang zur Datenbank (nicht identisch mit normalem Benutzer)
+
+# PhpMyAdmin ─ Zugriff ueber Web-GUI
+PMA_HOST=...				# Muss dem Namen des DB-Containers ensprechen (siehe docker-compose.yml, unter Services)
+PMA_USER=...				# Benutzer zur Anmeldung in phpMyAdmin
+PMA_PASSWORD=...			# Passendes Passwort (z.B. MARIADB_PASSWORD)


### PR DESCRIPTION
Fuegt eine oeffentlich teilbare .env-example-Datei hinzu, die alle benoetigten Umgebungsvariablen dokumentiert. Sensible Zugangsdaten wurden bewusst ausgelassen. Die tatsaechliche .env-Datei ist bereits in .gitignore eingetragen, um ein versehentliches Einchecken zu verhindern.

Enthaelt Platzhalter fuer:
- JWT-Secret
- MariaDB-Container-Konfiguration (Docker)
- phpMyAdmin-Zugangsdaten (Docker)