### PR TITLE
chore(github): add PR template for structured pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+### 🧱 Hintergrund
+
+<!-- Beschreibe kurz den Kontext des PRs.
+Was ist der technische oder fachliche Hintergrund?
+Warum wird diese Änderung benötigt? -->
+
+---
+
+### 📦 Änderungen im Detail
+
+<!-- Liste die konkreten Änderungen auf.
+Was wurde hinzugefügt, entfernt oder angepasst? -->
+
+- 
+- 
+- 
+
+---
+
+### 🎯 Ziel / Zweck des PRs
+
+<!-- Was soll mit diesem PR erreicht werden?
+Was ist das gewünschte Ergebnis? -->
+
+---
+
+### 🧪 Testhinweise
+
+<!-- Wie kann man die Änderungen testen?
+Gibt es manuelle oder automatische Tests? -->
+
+---
+
+### 📌 Hinweise für Reviewer:innen
+
+<!-- Gibt es etwas Besonderes zu beachten?
+Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->
+
+---
+
+### 🔄 Folgeänderungen (optional)
+
+<!-- Falls dieser PR Teil eines größeren Tasks oder Refactors ist,
+was kommt danach? -->
+
+- [ ] ...
+- [ ] ...


### PR DESCRIPTION
### Hintergrund

Um den Pull-Request-Prozess im Projekt zu standardisieren, wurde eine
PR-Vorlage (`pull_request_template.md`) eingefuehrt.

Sie stellt sicher, dass alle zukuenftigen PRs wichtige Informationen enthalten,
z. B. den technischen Hintergrund, die konkreten Aenderungen, Testhinweise
und Folgeaufgaben.

---

### Aenderungen im Detail

- Erstellt `.github/pull_request_template.md`
- Struktur: Hintergrund, Aenderungen, Ziel, Tests, Hinweise, Ausblick
- Vorlage wird automatisch in neuen PRs verwendet

---

### Ziel / Zweck des PRs

Erleichterung von Code-Reviews, bessere Dokumentation von Aenderungen und
einheitliche Kommunikationsstruktur bei Pull Requests.

---

### Folgeaenderungen

- Issue-Vorlagen koennten als naechster Schritt folgen
- README-Abschnitt „Beitragen“ koennte auf die Vorlage verlinken
