### PR TITLE
chore(docker-compose): add docker-compose setup for local development…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+
+services:
+    apache-php:
+        build: .
+        container_name: mini-php-apache-composer
+        # user: "1000:1000"
+        ports:
+            - "8080:80"
+        volumes:
+            - ./projekt:/var/www/app
+        #Führt bei jedem Containerstart Composer aus, damit der
+        #vendor/-Ordner im gemounteten Volume verfügbar ist
+        #apache2-foreground startet danach den Apache-Prozess wie üblich
+        command: sh -c "composer install && apache2-foreground"
+        #Sicherheitsfeature fuer Production
+        #cap_drop:
+            #- ALL
+        env_file:
+            - .env
+        depends_on:
+            - db
+
+    db:
+        image: mariadb:10.11
+        container_name: mariadb
+        env_file:
+            - .env
+        ports:
+            - "3306:3306"
+        volumes:
+            - db_data:/var/lib/mysql
+            - ./init-sql:/docker-entrypoint-initdb.d:ro
+            - ./sql-dumps:/dumps
+    
+    db-admin-tool:
+        image: phpmyadmin:5.2.1
+        container_name: php-my-admin
+        ports:
+            - "8082:80"
+        environment:
+            - PMA_HOST=db
+        env_file:
+            - .env
+        depends_on:
+            - db
+
+volumes:
+    db_data:
+    sql_dumps:


### PR DESCRIPTION
### Hintergrund

<!-- Beschreibe kurz den Kontext des PRs.
Was ist der technische oder fachliche Hintergrund?
Warum wird diese Änderung benötigt? -->

Zur Abloesung der bisherigen XAMPP-basierten Umgebung wurde ein Docker-Setup
eingefuehrt.

Dieses PR ergaenzt die Orchestrierung durch docker-compose.yml, um alle
Projektkomponenten containerisiert und reproduzierbar lauffaehig zu machen.

---

### Änderungen im Detail

<!-- Liste die konkreten Änderungen auf.
Was wurde hinzugefügt, entfernt oder angepasst? -->

- Fuegt docker-compose.yml mit 3 Services hinzu:
    - apache-php (per Dockerfile gebaut)
    - db (MariaDB mit Volumes, Init-Skripten)
    - db-admin-tool (PhpMyAdmin)
- Nutzt .env-Datei zur zentralen Konfiguration
- Composer wird bei jedem Containerstart automatisch ausgefuehrt
- Daten werden persistent gespeichert

---

### Ziel / Zweck des PRs

<!-- Was soll mit diesem PR erreicht werden?
Was ist das gewünschte Ergebnis? -->

Die bisherige manuelle Entwicklungsumgebung (XAMPP) durch eine vollstaendig
containerisierte Loesung auf Basis von Docker Compose ersetzen.
Ziel ist eine konsistente, plattformunabhaengige und versionierbare Projektumgebung.

---

### Testhinweise

<!-- Wie kann man die Änderungen testen?
Gibt es manuelle oder automatische Tests? -->

1. .env-Datei anlegen (z. B. durch Kopie von .env.example)
2. Projekt mit folgendem Befehl starten:
`docker-compose up --build`

- Die Anwendung ist unter http://localhost:8080 erreichbar
- PhpMyAdmin ist unter http://localhost:8082 verfügbar

---

### Hinweise für Reviewer:innen

<!-- Gibt es etwas Besonderes zu beachten?
Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->

- Die Containerstruktur bildet die Grundlage für zukuenftige CI/CD-Prozesse
- Composer wird bei jedem Containerstart automatisch ausgefuehrt
- SQL-Init-Skripte in init-sql werden nur beim ersten Start verwendet

---

### Folgeänderungen (optional)

<!-- Falls dieser PR Teil eines größeren Tasks oder Refactors ist,
was kommt danach? -->

- [x] Entfernen von XAMPP-spezifischen Anleitungen oder Konfigurationen
- [x] Aktualisierung der `README.md` mit Docker- und Compose-Anleitung
- [ ] Einrichtung von CI/CD (z. B. Build/Test über GitHub Actions)
