### PR TITLE
feat(db): add initial schema setup with users and todos tables

### DIFF
--- a/init-sql/001-init.sql
+++ b/init-sql/001-init.sql
@@ -1,0 +1,17 @@
+create table users(
+	id int AUTO_INCREMENT primary key,
+	email varchar(255) unique not null,
+	password varchar(255) not null,
+	surname varchar(255) not null,
+	first_name varchar(255) not null,
+	created_at timestamp default current_timestamp
+);
+
+create table todos(
+	id int auto_increment primary key,
+	user_id int not null,
+	title varchar(255) not null,
+	is_done boolean default false,
+	created_at timestamp default current_timestamp,
+	foreign key (user_id) references users(id) on delete cascade
+);


### PR DESCRIPTION
### Hintergrund

<!-- Beschreibe kurz den Kontext des PRs.
Was ist der technische oder fachliche Hintergrund?
Warum wird diese Änderung benötigt? -->

Im Zuge der Einfuehrung einer containerisierten Infrastruktur mit Docker und
Docker Compose wurde ein SQL-Initialisierungsskript benoetigt, um beim ersten
Start des Datenbankcontainers automatisch die Grundstruktur der Anwendung zu
erzeugen.

Die Datei init-sql/01-schema.sql definiert die Kern-Tabellenstruktur der
Anwendung (users, todos) und wird automatisch durch den MariaDB-Container beim
ersten Start ausgefuehrt.

---

### Änderungen im Detail

<!-- Liste die konkreten Änderungen auf.
Was wurde hinzugefügt, entfernt oder angepasst? -->

- Erstellt Datei init-sql/01-schema.sql zur Initialisierung der Datenbankstruktur
- Definiert zwei Tabellen:
    - users mit Feldern: id, email, password, surname, first_name, created_at
    - todos mit Foreign Key auf users.id und Feldern: id, user_id, title, is_done,
      created_at
- Basiert auf MariaDB und nutzt docker-compose zur Ausführung beim Containerstart

---

### Ziel / Zweck des PRs

<!-- Was soll mit diesem PR erreicht werden?
Was ist das gewünschte Ergebnis? -->

Bereitstellung eines versionierten, automatisch ausfuehrbaren Datenbank-Schemas
zur Sicherstellung, dass alle Entwickler:innen und Deployment-Umgebungen mit
einer einheitlichen Datenbankstruktur arbeiten.

---

### Testhinweise

<!-- Wie kann man die Änderungen testen?
Gibt es manuelle oder automatische Tests? -->

1. Stelle sicher, dass eine .env-Datei vorhanden ist
2. Fuehre docker-compose up --build aus
3. Nach dem Start:
    - Die Datenbank WebStart wird automatisch erstellt
    - Die Tabellen users und todos sind enthalten

---

### Hinweise für Reviewer:innen

<!-- Gibt es etwas Besonderes zu beachten?
Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->

- Das Skript wird nur beim ersten Start ausgefuehrt (standardmaeßiges Verhalten von MariaDB mit /docker-entrypoint-initdb.d)

- Bereits bestehende Volumes müssen geloescht werden, um das Skript erneut auszufuehren (docker volume rm <vol-name>)

---
