### PR TITLE
feat(public/todo): add dashboard UI and todo API integration

### DIFF
--- a/projekt/public/api/addUserTodo.php
+++ b/projekt/public/api/addUserTodo.php
@@ -1,0 +1,79 @@
+<?php
+	require_once '../../bootstrap/init.php';
+	header('Content-Type: application/json');
+	
+	$pdo = Database::getConnection();
+	
+	if($_SERVER['REQUEST_METHOD'] !== 'POST'){
+		//	Methode nicht erlaubt
+		http_response_code(405);
+		echo json_encode(['error' => 'Nur POST-Anfragen erlaubt']);
+		exit();
+	}
+	
+	//	JSON-Daten auslesen
+	$input = json_decode(file_get_contents('php://input'), true);
+	$titleTodo = $input['title'];
+	
+	if(!$titleTodo){
+		http_response_code(400);
+		echo json_encode(['error' => 'Todo-Titel muss angegeben werden']);
+		exit();
+	}
+	
+	function getBearerToken(): ?string{
+		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+		
+		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		if(empty($authHeader) && function_exists('apache_request_headers')){
+			$headers = apache_request_headers();
+			if(isset($headers['Authorization'])){
+				$authHeader = $headers['Authorization'];
+			}
+		}
+		
+		//	3.	Pruefe auf Bearer
+		if(str_starts_with($authHeader, 'Bearer ')){
+			return trim(substr($authHeader, 7));
+		}
+		
+		return null;
+	}
+	
+	$token = getBearerToken();
+	
+	if(!$token){
+		//	Bad Request
+		http_response_code(400);
+		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		exit();
+	}
+	
+	//	JWT ueberprufen
+	//	Neue Insanz der Klasse: JwtHandler
+	//	Konstruktoraufruf
+	$jwt = new \Core\JwtHandler();
+	$userData = $jwt->validateToken($token);
+	$userId = $jwt->getUserIdFromToken($token);
+	
+	if($userData === null){
+		http_response_code(401);
+		echo json_encode(['error' => $userData['message']]);
+		exit();
+	}
+	
+	$todoId = addTodo($pdo, $userId, $titleTodo);
+	
+	if($todoId !== null){
+		echo json_encode([
+			'success' => true,
+			'todoId' => $todoId
+		]);
+	}else{
+		echo json_encode([
+			'success' => false,
+			'message' => 'Fehler beim Hinzufuegen des Todos'
+		]);
+	}
+?>

--- a/projekt/public/api/deleteUserTodo.php
+++ b/projekt/public/api/deleteUserTodo.php
@@ -1,0 +1,85 @@
+<?php
+
+	/*
+		WICHTIG
+		WENN NUR EIN EINZELNES TODO IN DER LISTE IST, KOMMT ES ZU EINEM FEHLER BEIM LOESCHEN
+		BZW WIRD DIE ANZEIGE NICHT AKTUALISIERT
+	*/
+
+	require_once __DIR__ . '/../../bootstrap/init.php';
+	header('Content-Type: application/json');
+	
+	$pdo = Database::getConnection();
+	
+	if($_SERVER['REQUEST_METHOD'] !== 'DELETE'){
+		//	Methode nicht erlaubt
+		http_response_code(405);
+		echo json_encode(['error' => 'Nur DELETE-Anfragen erlaubt']);
+		exit();
+	}
+	
+	//	JSON-Daten auslesen
+	$input = json_decode(file_get_contents('php://input'), true);
+	$todoId = $input['id'];
+	
+	if(!$todoId){
+		http_response_code(400);
+		echo json_encode(['error' => 'Todo-ID muss angegeben werden']);
+		exit();
+	}
+	
+	function getBearerToken(): ?string{
+		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+		
+		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		if(empty($authHeader) && function_exists('apache_request_headers')){
+			$headers = apache_request_headers();
+			if(isset($headers['Authorization'])){
+				$authHeader = $headers['Authorization'];
+			}
+		}
+		
+		//	3.	Pruefe auf Bearer
+		if(str_starts_with($authHeader, 'Bearer ')){
+			return trim(substr($authHeader, 7));
+		}
+		
+		return null;
+	}
+	
+	$token = getBearerToken();
+	
+	if(!$token){
+		//	Bad Request
+		http_response_code(400);
+		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		exit();
+	}
+	
+	//	JWT ueberprufen
+	//	Neue Insanz der Klasse: JwtHandler
+	//	Konstruktoraufruf
+	$jwt = new \Core\JwtHandler();
+	$userData = $jwt->validateToken($token);
+	$userId = $jwt->getUserIdFromToken($token);
+	
+	if($userData === null){
+		http_response_code(401);
+		echo json_encode(['error' => $userData['message']]);
+		exit();
+	}
+	
+	$deleteSuccess = deleteTodo($pdo, $userId, $todoId);
+	
+	if($deleteSuccess){
+		echo json_encode(['success' => true]);
+		
+	}else{
+		http_response_code(404);
+		echo json_encode([
+			'success' => false,
+			'message'=> 'Todo wurde nicht gefunden oder konnte nicht geloescht werden'
+		]);
+	}
+?>

--- a/projekt/public/api/get_user_todos.php
+++ b/projekt/public/api/get_user_todos.php
@@ -1,0 +1,77 @@
+<?php
+	require_once __DIR__ . '/../../bootstrap/init.php';
+	header('Content-Type: application/json');
+	
+	$pdo = Database::getConnection();
+	
+	if($_SERVER['REQUEST_METHOD'] !== 'GET'){
+		//	Methode nicht erlaubt
+		http_response_code(405);
+		echo json_encode(['error' => 'Nur Get-Anfragen erlaubt']);
+		exit();
+	}
+	
+	function getBearerToken(): ?string{
+		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+		
+		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		if(empty($authHeader) && function_exists('apache_request_headers')){
+			$headers = apache_request_headers();
+			if(isset($headers['Authorization'])){
+				$authHeader = $headers['Authorization'];
+			}
+		}
+		
+		//	3.	Pruefe auf Bearer
+		if(str_starts_with($authHeader, 'Bearer ')){
+			return trim(substr($authHeader, 7));
+		}
+		
+		return null;
+	}
+	
+	$token = getBearerToken();
+	
+	if(!$token){
+		//	Bad Request
+		http_response_code(400);
+		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		exit();
+	}
+	
+	//	JWT ueberprufen
+	//	Neue Insanz der Klasse: JwtHandler
+	//	Konstruktoraufruf
+	$jwt = new \Core\JwtHandler();
+	$userData = $jwt->validateToken($token);
+	$userId = $jwt->getUserIdFromToken($token);
+	
+	if($userData === null){
+		http_response_code(401);
+		echo json_encode(['error' => $userData['message']]);
+		exit();
+	}
+	
+	//	Nutzerdaten aus DB holen
+	$userTodos = getTodosByUser($pdo, $userId);
+	
+	if(!is_array($userTodos)){
+		http_response_code(500);
+		echo json_encode(['error' => 'Benutzer-Todos nicht gefunden']);
+		exit();
+	}
+	
+	$formattedTodos = [];
+	
+	foreach($userTodos as $todo){
+		$formattedTodos[] = [
+			'todo_id' => $todo['id'],
+			'todo_title' => $todo['title'],
+			'todo_status' => $todo['is_done'],
+			'todo_iat' => $todo['created_at']
+		];
+	}
+	
+	echo json_encode($formattedTodos);
+?>

--- a/projekt/public/api/toggleUserTodoStatus.php
+++ b/projekt/public/api/toggleUserTodoStatus.php
@@ -1,0 +1,79 @@
+<?php
+	require_once __DIR__ . '/../../bootstrap/init.php';
+	header('Content-Type: application/json');
+	
+	$pdo = Database::getConnection();
+	
+	if($_SERVER['REQUEST_METHOD'] !== 'PATCH'){
+		//	Methode nicht erlaubt
+		http_response_code(405);
+		echo json_encode(['error' => 'Nur PATCH-Anfragen erlaubt']);
+		exit();
+	}
+	
+	//	JSON-Daten auslesen
+	$input = json_decode(file_get_contents('php://input'), true);
+	$todoId = $input['id'] ?? '';
+	
+	if(!$todoId){
+		http_response_code(400);
+		echo json_encode(['error' => 'Todo-ID erforderlich']);
+		exit();
+	}
+	
+	function getBearerToken(): ?string{
+		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+		
+		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		if(empty($authHeader) && function_exists('apache_request_headers')){
+			$headers = apache_request_headers();
+			if(isset($headers['Authorization'])){
+				$authHeader = $headers['Authorization'];
+			}
+		}
+		
+		//	3.	Pruefe auf Bearer
+		if(str_starts_with($authHeader, 'Bearer ')){
+			return trim(substr($authHeader, 7));
+		}
+		
+		return null;
+	}
+	
+	$token = getBearerToken();
+	
+	if(!$token){
+		//	Bad Request
+		http_response_code(400);
+		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		exit();
+	}
+	
+	//	JWT ueberprufen
+	//	Neue Insanz der Klasse: JwtHandler
+	//	Konstruktoraufruf
+	$jwt = new \Core\JwtHandler();
+	$userData = $jwt->validateToken($token);
+	$userId = $jwt->getUserIdFromToken($token);
+	
+	if($userData === null){
+		http_response_code(401);
+		echo json_encode(['error' => $userData['message']]);
+		exit();
+	}
+	
+	//	Toggle-Funktion ruft Status zurueck
+	$todoStatus = toggleTodo($pdo, $userId, $todoId);
+	
+	if($todoStatus === 1){
+		echo json_encode(['todoStatus' => 'Done']);
+	}else if($todoStatus === 0){
+		echo json_encode(['todoStatus' => 'In Progress']);
+	}else{
+		http_response_code(401);
+		echo json_encode(['error' => 'Status wurde nicht geaendert']);
+		exit();
+	}
+	
+?>

--- a/projekt/public/api/user_info.php
+++ b/projekt/public/api/user_info.php
@@ -1,0 +1,74 @@
+<?php
+	require_once __DIR__ . '/../../bootstrap/init.php';
+	header('Content-Type: application/json');
+	
+	$pdo = Database::getConnection();
+	
+	if($_SERVER['REQUEST_METHOD'] !== 'GET'){
+		//	Methode nicht erlaubt
+		http_response_code(405);
+		echo json_encode(['error' => 'Nur Get-Anfragen erlaubt']);
+		exit();
+	}
+	
+	function getBearerToken(): ?string{
+		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+		
+		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		if(empty($authHeader) && function_exists('apache_request_headers')){
+			$headers = apache_request_headers();
+			if(isset($headers['Authorization'])){
+				$authHeader = $headers['Authorization'];
+			}
+		}
+		
+		//	3.	Pruefe auf Bearer
+		if(str_starts_with($authHeader, 'Bearer ')){
+			return trim(substr($authHeader, 7));
+		}
+		
+		return null;
+	}
+	
+	$token = getBearerToken();
+	
+	if(!$token){
+		//	Bad Request
+		http_response_code(400);
+		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		exit();
+	}
+	
+	//	JWT ueberprufen
+	//	Neue Insanz der Klasse: JwtHandler
+	//	Konstruktoraufruf
+	$jwt = new \Core\JwtHandler();
+	$userData = $jwt->validateToken($token);
+	$userId = $jwt->getUserIdFromToken($token);
+	
+	if($userData === null){
+		http_response_code(401);
+		echo json_encode(['error' => $userData['message']]);
+		exit();
+	}
+	
+	//	Nutzerdaten aus DB holen
+	//	Das koennte man doch aus auslagern, damit der Webserver
+	//	hierrauf keinen Zugriff gibt ueber public?
+	$stmt = $pdo->prepare("select first_name, surname from users where id = ?");
+	$stmt->execute([$userId]);
+	$user = $stmt->fetch();
+	
+	if(!$user){
+		http_response_code(404);
+		echo json_encode(['error' => 'Benutzer nicht gefunden']);
+		exit();
+	}
+	
+	echo json_encode([
+		'user_id' => $userId,
+		'surname' => $user['surname'],
+		'first_name' => $user['first_name']
+	]);
+?>

--- a/projekt/public/html/dashboard.html
+++ b/projekt/public/html/dashboard.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="de">
+	<head>
+		<meta	charset="utf-8">
+		<title>Dashboard</title>
+	</head>
+	
+	<body>
+		<!--
+			Wilkommensnachricht dynamisch per JS hinzufuegen
+		-->
+		<h1	id="userWelcome"></h1>
+		
+		<!--
+			Logout
+		-->
+		<button	id="logoutBtn">Logout</button>
+		
+		<!--
+			Alle Aufgaben dynamisch per JS einfuegen
+		-->
+		<h2	id="ulHeader"></h2>
+		
+		<!--
+			Wenn Eintraege vorhanden sind
+		-->
+		<ul	id="todoRecord">
+		</ul>
+		
+		<!--
+			Neue Aufagben per API hinzufuegen
+		-->
+		<h2>Add ToDo</h2>
+		<form	id="addTodoForm">
+			<label	for="title"></label>
+			<input	type="text"	id="title"	placeholder="Aufgabenname"	required>
+			
+			<button	type="submit">Aufgabe hinzufügen</button>
+		</form>
+		
+		<p	id="messageAddTodo">
+			
+		</p>
+		
+		<script	src="/js/dashboard.js"></script>
+		<script	src="/js/logout.js"></script>
+	</body>
+</html>

--- a/projekt/public/js/dashboard.js
+++ b/projekt/public/js/dashboard.js
@@ -1,0 +1,300 @@
+document.addEventListener("DOMContentLoaded", () => {
+	const welcomeMessageH1 = document.getElementById("userWelcome");
+	const todoRecordUl = document.getElementById("todoRecord");
+	const todoRecordP = document.getElementById("todoRecordEmpty");
+	const addTodoForm = document.getElementById("addTodoForm");
+	const messageAddTodo = document.getElementById("messageAddTodo");
+	
+	const token = localStorage.getItem("jwt_token");
+	/*
+		Abrufen der User-ID, um die Ueberschrift zu erstellen => welcomeMessageH1
+		Diese Funktion in ein Modul auslagern, weil man so etwas noch an
+		anderer Stelle gebrauchen koennte.
+		
+		Und in Tablle users noch einen Namen einfuegen und die Regestrierung anpassen
+		Name soll eingegeben werden.
+	*/
+	//	async-Funktion innerhalb von anderer Funktion
+	async function loadUserData(){
+		try{
+			//	Diese Anfrage nutzt die Get-Methode, weil wir hier nichts eingeben
+			//	wollen in die API, sondern lediglich eine Information abrufen wollen?
+			
+			const response = await fetch("/api/user_info.php", {
+				method: "GET",
+				headers: {
+					"Authorization": `Bearer ${token}`,
+					"Content-Type": "application/json"
+				}
+			});
+		
+			const contentType = response.headers.get("Content-Type") || "";
+		
+			if(contentType.includes("application/json")){
+				const data = await response.json();
+				console.log("Antwort vom Server:", data);
+			
+				if(response.ok && data.surname && data.first_name){
+					welcomeMessageH1.textContent = `Welcome, ${data.first_name} ${data.surname}`;
+				}else{
+					welcomeMessageH1.textContent = data.error || "Name konnte nicht abgerufen werden, weil nicht gesetzt.";
+				}
+			}else{
+				const text = await response.text();
+				console.log("Fehlerantwort (kein JSON):", text);
+				welcomeMessageH1.textContent = "Serverfehler: Unerwartete Antwort";
+			}
+		}catch(err){
+			console.error("Fehler beim Login:", err);
+			welcomeMessageH1.textContent = "Netzwerkfehler oder Server nicht erreichbar.";
+		}
+	}
+	
+	async function loadUserTodos(){
+		try{
+			const response = await fetch("/api/get_user_todos.php", {
+				method: "GET",
+				headers: {
+					"Authorization":`Bearer ${token}`,
+					"Content-Type":"application/json"
+				}
+			});
+			
+			const contentType = response.headers.get("Content-Type") || "";
+			
+			if(contentType.includes("application/json")){
+				const data = await response.json();
+				console.log("Antwort vom Server:", data);
+				
+				if(response.ok){
+					console.log('hier die todo daten', data);
+					
+					//	Das ist der sogenannte “State Reset”-Ansatz, und er wird auch in vielen
+					//	React/SPA-Frameworks standardmäßig genutzt.
+					//	Nach erfolgreichem Abruf des API-Endpunkts wird die Anzeige der Todos refresht
+					//	In Kombination mit toggleUserTodoStatus() (Statusaenderung) und addUserTodo() (neues Todo)
+					todoRecordUl.innerHTML = '';
+					
+					//	Setzen der Todo-Liste-Ueberschrift
+					const ulHeaderH2 = document.getElementById("ulHeader");
+					if(data.length > 0){
+						ulHeaderH2.textContent = "Your ToDos";
+							data.forEach(todo => {
+								//	Erstellt einen li-Tag pro Eintrag
+								const li = document.createElement("li");
+						
+								//	Erstellt einen Text-Container fuer Infos zum Todo
+								const textDiv = document.createElement("div");
+						
+								//	Title - Todo
+								const todoTitle = document.createElement("h3");
+								todoTitle.textContent = todo.todo_title;
+						
+								//	Checkbox - Todo - Input, das in Label gepackt wird
+								const todoCheckbox = document.createElement("input");
+								todoCheckbox.type = "checkbox";
+								todoCheckbox.dataset.id = todo.todo_id;
+								todoCheckbox.checked = todo.todo_status == 1;
+						
+								//	Status-Text fuer Checkbox
+								const checkboxStatusText = document.createTextNode(
+									todo.todo_status == 1 ? " Done" : " In Progress"
+								);
+						
+								//	Label fuer den Status-Text
+								const labelStatusText = document.createElement("label");
+								labelStatusText.appendChild(todoCheckbox);
+								labelStatusText.appendChild(checkboxStatusText);
+						
+								//	Created - Iat
+								const todoIat = document.createElement("h4");
+								todoIat.textContent = todo.todo_iat;
+						
+								//	Button zum Loeschen eines Todo-Eintrag
+								const deleteButton = document.createElement("button");
+								deleteButton.textContent = "Loeschen";
+								deleteButton.dataset.id = todo.todo_id;
+						
+								//	Daten in Div einhaengen
+								textDiv.appendChild(todoTitle);
+								textDiv.appendChild(labelStatusText);
+								textDiv.appendChild(todoIat);
+								textDiv.appendChild(deleteButton);
+						
+								//	textDiv jeweils in ein li einhaengen
+								li.appendChild(textDiv);
+						
+								//	lis in ul einhaengen
+								todoRecordUl.appendChild(li);
+						
+								todoCheckbox.addEventListener("change", (e) => {
+									const id = e.target.dataset.id;
+									const status = e.target.checked;
+									toggleUserTodoStatus(id);
+								});
+						
+								deleteButton.addEventListener("click", () => {
+									deleteUserTodo(todo.todo_id);
+								});
+							});
+						}else{
+							ulHeaderH2.textContent = "No todos available";
+							todoRecordUl.innerHTML = "<li>Nothing to do - Relax</li>";
+						}
+				}else{
+					console.error("Irgendein Fehler beim Abrufen von: get_user_todos.php");
+				}
+			}else{
+				const text = await response.text();
+				console.log("Fehlerantwort (kein JSON):", text);
+			}
+		}catch(err){
+			console.error("Irgendein Fehler beim Abrufen von: get_user_todos.php:", err);
+		}
+	}
+	
+	async function toggleUserTodoStatus(id){
+		try{
+			const response = await fetch("/api/toggleUserTodoStatus.php", {
+				method: "PATCH",
+				headers: {
+					"Authorization":`Bearer ${token}`,
+					"Content-Type":"application/json"
+				},
+				body: JSON.stringify({id})
+			});
+			
+			const contentType = response.headers.get("Content-Type") || "";
+			
+			if(contentType.includes("application/json")){
+				const data = await response.json();
+				console.log("Antwort vom Server:", data);
+				
+				if(response.ok){
+					//	Das ist der sogenannte “State Reset”-Ansatz, und er wird auch in vielen
+					//	React/SPA-Frameworks standardmäßig genutzt.
+					//	Nach erfolgreichem Abruf des API-Endpunkts wird die Anzeige der Todos refresht
+					//	In Kombination mit loadUserTodos()
+					loadUserTodos();
+					console.log('der neue Status des Todos:', data);
+				}else{
+					console.error("Irgendein Fehler beim Abrufen von: toggleUserTodoStatus.php");
+				}
+			}else{
+				const text = await response.text();
+				console.log("Fehlerantwort (kein JSON):", text);
+			}
+		}catch(err){
+			console.error("Irgendein Fehler beim Abrufen von: toggleUserTodoStatus.php", err);
+		}
+	}
+	
+	//	addUserTodo - Anfang
+	async function addUserTodo(title){
+		try{
+			const response = await fetch("/api/addUserTodo.php", {
+				method: "POST",
+				headers: {
+					"Authorization":`Bearer ${token}`,
+					"Content-Type":"application/json"
+				},
+				body: JSON.stringify({title})
+			});
+			
+			const contentType = response.headers.get("Content-Type") || "";
+			
+			if(contentType.includes("application/json")){
+				const data = await response.json();
+				console.log("Antwort vom Server:", data);
+				
+				if(response.ok){
+					//	Das ist der sogenannte “State Reset”-Ansatz, und er wird auch in vielen
+					//	React/SPA-Frameworks standardmäßig genutzt.
+					//	Nach erfolgreichem Abruf des API-Endpunkts wird die Anzeige der Todos refresht
+					//	In Kombination mit loadUserTodos()
+					loadUserTodos();
+					console.log("Die neue Todo-Liste:", data);
+					return data;
+				}else{
+					console.error("Irgendein Fehler beim Abrufen von: addUserTodo.php");
+				}
+			}else{
+				const text = await response.text();
+				console.log("Fehlerantwort (kein JSON):", text);
+			}
+		}catch(err){
+			console.error("Irgendein Fehler beim Abrufen von: addUserTodo.php");
+		}
+	}
+	
+	//	Was wenn ich auf einer Seite mehr als ein submit-Event habe,
+	//	wie muessen die Eventlistener angepasst werden?
+	addTodoForm.addEventListener("submit", async (e) => {
+		e.preventDefault();
+		
+		const newTodoTitle = document.getElementById("title");
+		const title = newTodoTitle.value.trim();
+		
+		if(!title){
+			messageAddTodo.textContent = "Bitte einen Titel eingeben.";
+			return;
+		}
+		
+		const result = await addUserTodo(title);
+		
+		if(result.success){
+			messageAddTodo.textContent = "Successfully added new todo";
+			//	Eingabe zuruecksetzen
+			newTodoTitle.value = "";
+		}else{
+			messageAddTodo.textContent = result.message;
+		}
+	});
+	
+	//	addUserTodo - Ende
+	
+	/*
+		WICHTIG
+		WENN NUR EIN EINZELNES TODO IN DER LISTE IST, KOMMT ES ZU EINEM FEHLER BEIM LOESCHEN
+		BZW WIRD DIE ANZEIGE NICHT AKTUALISIERT
+	*/
+	
+	async function deleteUserTodo(id){
+		try{
+			const response = await fetch('/api/deleteUserTodo.php', {
+				method: "DELETE",
+				headers: {
+					"Authorization":`Bearer ${token}`,
+					"Content-Type":"application/json"
+				},
+				body: JSON.stringify({id})
+			});
+			
+			const contentType = response.headers.get("Content-Type") || "";
+			
+			if(contentType.includes("application/json")){
+				const data = await response.json();
+				console.log("Antwort vom Server:", data);
+				
+				if(response.ok){
+					//	Das ist der sogenannte “State Reset”-Ansatz, und er wird auch in vielen
+					//	React/SPA-Frameworks standardmäßig genutzt.
+					//	Nach erfolgreichem Abruf des API-Endpunkts wird die Anzeige der Todos refresht
+					//	In Kombination mit loadUserTodos()
+					loadUserTodos();
+					console.log("Die neue Todo-Liste:", data);
+				}else{
+					console.error("Irgendein Fehler beim Abrufen von: deleteUserTodo.php");
+				}
+			}else{
+				const text = await response.text();
+				console.log("Fehlerantwort (kein JSON):", text);
+			}
+		}catch(err){
+			console.error("Irgendein Fehler beim Abrufen von: deleteUserTodo.php");
+		}
+	}
+	
+	loadUserData();
+	loadUserTodos();
+});


### PR DESCRIPTION
### Hintergrund

<!-- Beschreibe kurz den Kontext des PRs.
Was ist der technische oder fachliche Hintergrund?
Warum wird diese Änderung benötigt? -->

Dieser PR fuehrt das Dashboard-Modul der Anwendung ein. Es bietet eine einfache
Benutzeroberflaeche zur Verwaltung von Todos sowie mehrere zugehoerige
API-Endpunkte.

Alle Funktionen basieren auf JWT-basierter Authentifizierung und sind ueber das
zentrale Bootstrap-Modul eingebunden. Die Todos werden benutzerspezifisch
geladen, geaendert und geloescht. Auch Benutzerinformationen (Name) werden
dynamisch eingeblendet.

---

### Änderungen im Detail

<!-- Liste die konkreten Änderungen auf.
Was wurde hinzugefügt, entfernt oder angepasst? -->

#### UI
- `dashboard.html`: HTML-Struktur mit Formular zur Todo-Erstellung, Liste bestehender Todos, Logout-Button

#### JavaScript
- `dashboard.js`:
	- Holt Benutzernamen (API: `user_info.php`)
	- Laedt Todos des eingeloggten Nutzers (API: `get_user_todos.php`)
	- Hinzufuegen eines Todos (`addUserTodo.php`)
	- Status aendern per Checkbox (`toggleUserTodoStatus.php`)
	- Loeschen eines Todos (`deleteUserTodo.php`)
	- Alle Funktionen setzen auf JWT-Auth im Header

#### Backend (API-Endpunkte)
- `addUserTodo.php`: Fuegt neues Todo hinzu
- `deleteUserTodo.php`: Loescht Todo eines Benutzers
- `get_user_todos.php`: Gibt alle Todos eines Benutzers zurueck
- `toggleUserTodoStatus.php`: Aendert Status (done <-> not done)
- `user_info.php`: Gibt Namen des eingeloggten Nutzers zurueck

---

### Ziel / Zweck des PRs

<!-- Was soll mit diesem PR erreicht werden?
Was ist das gewünschte Ergebnis? -->

- Ermoeglicht authentifizierten Benutzern die Verwaltung ihrer Todos
- Einfuehrung eines zentralen, reaktiven UI-Moduls
- Modularer Zugriff auf alle Todos via API

---

### Testhinweise

<!-- Wie kann man die Änderungen testen?
Gibt es manuelle oder automatische Tests? -->

1. Mit Benutzer einloggen (ueber `login.html`)
2. `dashboard.html` im Browser öffnen
3. Funktional testen:
	- Todos anzeigen
	- Todos hinzufuegen
	- Todos als erledigt markieren
	- Todos loeschen
	- Logout (Button vorhanden, aber Logik separat)

Alle API-Anfragen muessen mit gueltigem Token im Header ablaufen.

---

### Hinweise für Reviewer:innen

<!-- Gibt es etwas Besonderes zu beachten?
Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->

- API-Zugriff nur mit Bearer-Token
- Token wird im Frontend via `localStorage` gespeichert
- Dashboard-Skript (JS) sollte in Zukunft modularisiert werden (z. B. `modules/user.js`, `modules/todo.js`)
- API-Funktionen nutzen gemeinsame Struktur: Authentifizierung → Datenbankzugriff → JSON-Ausgabe

---

### Folgeänderungen (optional)

<!-- Falls dieser PR Teil eines größeren Tasks oder Refactors ist,
was kommt danach? -->

- [ ] Fehlerbehandlung zentralisieren (Frontend + Backend)
- [ ] Unit-Tests für API-Endpunkte ergaenzen
- [ ] Todo-Logik in JS modularisieren
