### PR TITLE
feat(src/todo): add todo module with CRUD functionality

### DIFF
--- a/projekt/src/todo/todo.php
+++ b/projekt/src/todo/todo.php
@@ -1,0 +1,58 @@
+<?php
+	function getTodosByUser($pdo, $userId){
+		$stmt = $pdo->prepare("select * from todos where user_id = ? order by created_at asc");
+		$stmt->execute([$userId]);
+		
+		return $stmt->fetchAll();
+	}
+	
+	function addTodo($pdo, $userId, $title){
+		if(trim($title) === ''){
+			throw new InvalidArgumentException('Titel darf nicht leer sein.');
+		}
+		
+		if(strlen($title) > 255){
+			throw new InvalidArgumentException('Title darf nicht länger als 255 Zeichen sein.');
+		}
+		
+		$stmt = $pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userId, $title]);
+		
+		$todoId = (int)$pdo->lastInsertId();
+		
+		$stmt = $pdo->prepare("select id from todos where id = ? and user_id = ?");
+		$stmt->execute([$todoId, $userId]);
+		$todo = $stmt->fetch();
+		
+		return $todo ? (int)$todo['id'] : null;
+	}
+	
+	function getTodotatus($pdo, $todoId, $userId){
+		$stmt = $pdo->prepare("select is_done from todos where id = ? and user_id = ?");
+		$stmt->execute([$todoId, $userId]);
+		$todo = $stmt->fetch();
+		
+		//	Wenn Status von Todo auf is_done dann:
+		//	return = 1, sonst
+		//	return 0
+		//	Eintrag gefunden, is_done = 0 -> Todo nicht erledigt
+		//	Eintrag gefunden, is_done = 1 -> Todo erledigt
+		//	Kein Eintrag gefunden (fetch() gibt false) -> null, todo existiert nicht oder Fehler
+		return $todo ? (int)$todo['is_done'] : null;
+	}
+	
+	function toggleTodo($pdo, $userId, $todoId){
+		$stmt = $pdo->prepare("update todos set is_done = not is_done where id = ? and user_id = ?");
+		$stmt->execute([$todoId, $userId]);
+		
+		return  getTodotatus($pdo, $todoId, $userId);
+	}
+	
+	function deleteTodo($pdo, $userId, $todoId){
+		$stmt = $pdo->prepare("delete from todos where id = ? and user_id = ?");
+		$stmt->execute([$todoId, $userId]);
+		
+		//	true, wenn geanu eine Zeile geloescht wurde
+		return $stmt->rowCount() === 1;
+	}
+?>


### PR DESCRIPTION
### Hintergrund

<!-- Beschreibe kurz den Kontext des PRs.
Was ist der technische oder fachliche Hintergrund?
Warum wird diese Änderung benötigt? -->

Dieser PR fuehrt das ToDo-Modul der Anwendung ein. Es kapselt saemtliche
Datenbankoperationen rund um Aufgaben – von Erstellen ueber Statuswechsel bis
zur Loeschung.

Die Datei `src/todo/todo.php` wird ueber `bootstrap/init.php` eingebunden und
steht damit den API-Endpunkten im `public/api/`-Verzeichnis zur Verfuegung.

---

### Änderungen im Detail

<!-- Liste die konkreten Änderungen auf.
Was wurde hinzugefügt, entfernt oder angepasst? -->

#### `getTodosByUser($pdo, $userId)`
- Holt alle Todos eines Nutzers
- Sortierung nach Erstellungsdatum (ASC)

#### `addTodo($pdo, $userId, $title)`
- Validiert Titel
- Fuegt Todo hinzu
- Gibt ID des neuen Eintrags zurueck

#### `getTodotatus($pdo, $todoId, $userId)`
- Liest aktuellen Status (is_done) eines Todos

#### `toggleTodo($pdo, $userId, $todoId)`
- Kehrt den Status `is_done` um
- Gibt neuen Status zurueck

#### `deleteTodo($pdo, $userId, $todoId)`
- Loescht Eintrag
- Rueckgabe: `true`, wenn 1 Zeile geloescht wurde

---

### Ziel / Zweck des PRs

<!-- Was soll mit diesem PR erreicht werden?
Was ist das gewünschte Ergebnis? -->

- Bereitstellung der zentralen Geschaeftslogik für Todo-Verwaltung
- Entkopplung von API-Endpunkten und Datenzugriff
- Ermoeglicht Testbarkeit & Wiederverwendbarkeit

---

### Testhinweise

<!-- Wie kann man die Änderungen testen?
Gibt es manuelle oder automatische Tests? -->

- API-Endpunkte wie `addUserTodo.php`, `deleteUserTodo.php` etc. nutzen diese Funktionen
- Test durch API-Calls mit Auth-Token

---

### Hinweise für Reviewer:innen

<!-- Gibt es etwas Besonderes zu beachten?
Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->

- Eingabevalidierung erfolgt **vor dem Insert**
- Statuswechsel (toggle) basiert auf `NOT is_done` in SQL
- Alle Queries sind per `prepare()` vorbereitet

---

### Folgeänderungen (optional)

<!-- Falls dieser PR Teil eines größeren Tasks oder Refactors ist,
was kommt danach? -->

- [ ] Filter- und Sortierfunktionen für größere Todo-Listen
