### PR TITLE
test(todo): add legacy PHPUnit tests for todo functionality

### DIFF
--- a/projekt/tests/todo/AddTodoTest.php
+++ b/projekt/tests/todo/AddTodoTest.php
@@ -1,0 +1,140 @@
+<?php
+//	funktionen_tests.php
+use PHPUnit\Framework\TestCase;
+	
+require_once __DIR__ . '/../todo.php';
+require_once __DIR__ . '/../db.php';
+	
+//	Testklasse für addTodo()
+class AddTodoTest extends TestCase
+{
+	private PDO $pdo;
+	
+	protected function setUp(): void{
+		$this->pdo = new PDO("sqlite::memory:");
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$this->pdo->exec('pragma foreign_keys = on');
+		
+		//	Benutzer- und Todos-Tabelle erstellen
+		$this->pdo->exec("
+			create table users(
+				id integer primary key autoincrement,
+				email varchar(255) unique not null,
+				password varchar(255) not null,
+				created_at timestamp default current_timestamp
+			);
+		");
+		
+		$this->pdo->exec("
+			create table todos(
+				id integer primary key autoincrement,
+				user_id int not null,
+				title varchar(255) not null,
+				is_done boolean default false,
+				created_at timestamp default current_timestamp,
+				foreign key (user_id) references users(id) on delete cascade
+			);
+		");
+		
+		$stmt = $this->pdo->prepare("insert into users (email, password) values (?, ?)");
+		$stmt->execute(['test@test.de', password_hash('EinPasswort123-', PASSWORD_DEFAULT)]);
+	}
+
+	/*
+		Test Nr. 1
+		Hinzufügen eines Todos in die DB, eines bestimmten Benutzers.
+		Es wird geprüft, ob ein Todo erfolgreich in die DB eingefügt wird.
+	*/
+	public function testAddTodoInsertsRowCorrectly(){
+		$userId = 1;
+		$title = 'Ein neues Todo';
+		
+		addTodo($this->pdo, $userId, $title);
+		
+		$stmt = $this->pdo->prepare("select * from todos where user_id = ?");
+		$stmt->execute([$userId]);
+		$todos = $stmt->fetchAll();
+		
+		$this->assertCount(1, $todos);
+		$this->assertEquals($title, $todos[0]['title']);
+		$this->assertEquals(0, $todos[0]['is_done']);
+	}
+	
+	/*
+		Test Nr. 2
+		Prüfen, wie sich die Funktion verhält, wenn probiert wird ein Todo ohne
+		bzw. mit leerem Titel in die DB einzufügen.
+	*/
+	public function testAddTodoWithEmptyTitleThrowsException(){
+		$userId = 1;
+		$title = '';
+		
+		$this->expectException(InvalidArgumentException::class);
+		$result = addTodo($this->pdo, $userId, $title);
+	}
+	
+	/*
+		Test Nr. 3
+		Prüfen, wie sich die Funktion verhält, wenn eine ungültige BenutzerID
+		angegeben wird bzw. dieser BenutzerID ein Todo zugeordnet werden soll.
+	*/
+	public function testAddTodoWithInvalidUserIdThrowsException(){
+		$userId = 999;
+		$title = 'Ganz was Neues';
+		
+		$this->expectException(PDOException::class);
+		$result = addTodo($this->pdo, $userId, $title);
+	}
+	
+	/*
+		Test Nr. 4
+		Prüft das Verhalten bei einer SQL-Injection
+		Im Titel wird eine SQL-Injection an die DB übergeben.
+		
+		Wichtig
+		Über prepare()-Methode wird SQL-Injection ausgehebelt
+	*/
+	public function testAddTodoWithSQLInjectionLikeInputIsStoredSafely(){
+		$userId = 1;
+		$title = "Test'); drop table todos;--";
+		
+		addTodo($this->pdo, $userId, $title);
+		
+		$stmt = $this->pdo->prepare("select title from todos where user_id = ?");
+		$stmt->execute([$userId]);
+		$todo = $stmt->fetch();
+		
+		$this->assertEquals($title, $todo['title']);
+	}
+	
+	/*
+		Test Nr. 5.1
+		Prüft das Verhalten, wenn maximal zulässige Länge des Titels
+		ausgereizt wird (Titel aus 255 characters).
+	*/
+	public function testAddTodoWith255CharTitleSucceeds(){
+		$userId = 1;
+		$title = str_repeat('a', 255);
+		
+		addTodo($this->pdo, $userId, $title);
+		
+		$stmt = $this->pdo->prepare("select title from todos where user_id = ?");
+		$stmt->execute([$userId]);
+		$todo = $stmt->fetch();
+		
+		$this->assertEquals($title, $todo['title']);
+	}
+	
+	/*
+		Test Nr. 5.2
+		Prüft das Verhalten, wenn maximal zulässige Länge des Titels
+		überschritten wird (Titel > 255 characters).
+	*/
+	public function testAddTodoWith256CharTitleThrowsException(){
+		$userId = 1;
+		$title = str_repeat('a', 234256);
+		
+		$this->expectException(InvalidArgumentException::class);
+		addTodo($this->pdo, $userId, $title);
+	}
+}

--- a/projekt/tests/todo/DeleteTodoTest.php
+++ b/projekt/tests/todo/DeleteTodoTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+	Sollten noch globale Variablen vor Tests geleert?
+	Gilt für alle Todo-Funktionen
+*/
+
+//	funktionen_tests.php
+use PHPUnit\Framework\TestCase;
+	
+require_once __DIR__ . '/../todo.php';
+require_once __DIR__ . '/../db.php';
+	
+//	Testklasse für deleteTodo()
+class DeleteTodoTest extends TestCase
+{
+	private PDO $pdo;
+	
+	protected function setUp(): void{
+		$this->pdo = new PDO("sqlite::memory:");
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$this->pdo->exec('pragma foreign_keys = on');
+		
+		//	Benutzer- und Todos-Tabelle erstellen
+		$this->pdo->exec("
+			create table users(
+				id integer primary key autoincrement,
+				email varchar(255) unique not null,
+				password varchar(255) not null,
+				created_at timestamp default current_timestamp
+			);
+		");
+		
+		$this->pdo->exec("
+			create table todos(
+				id integer primary key autoincrement,
+				user_id int not null,
+				title varchar(255) not null,
+				is_done boolean default false,
+				created_at timestamp default current_timestamp,
+				foreign key (user_id) references users(id) on delete cascade
+			);
+		");
+		
+		$stmt = $this->pdo->prepare("insert into users (email, password) values (?, ?)");
+		$stmt->execute(['test@test.de', password_hash('EinPasswort123-', PASSWORD_DEFAULT)]);
+	}
+
+	/*
+		Test Nr. 1
+		Prüfen, ob ein Todo korrekt gelöscht wird, wenn ein gültiger Benutzer
+		es löscht.
+	*/
+	public function testDeleteTodoRemovesTodoFromDatabase(){
+		$userId = 1;
+		$title = 'Ein Todo';
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userId, $title]);
+		$todoId = $this->pdo->lastInsertId();
+		
+		deleteTodo($this->pdo, $userId, $todoId);
+		
+		$stmt = $this->pdo->prepare("select count(*) from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$count = $stmt->fetchColumn();
+		
+		$this->assertEquals(0, $count);
+	}
+	
+	/*
+		Test Nr. 2
+		Ein Benutzer darf nicht fremde Todos löschen.
+	*/
+	public function testDeleteTodoWithWrongUserDoesNotDelete(){
+		$ownerId = 1;
+		$wrongUserId = 2;
+		$title = 'Fremdes Todo';
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$ownerId, $title]);
+		$todoId = $this->pdo->lastInsertId();
+		
+		deleteTodo($this->pdo, $wrongUserId, $todoId);
+		
+		$stmt = $this->pdo->prepare("select count(*) from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$count = $stmt->fetchColumn();
+		
+		$this->assertEquals(1, $count);
+	}
+	
+	/*
+		Test Nr. 3
+		Wenn das Todo gar nicht existiert, soll nichts passieren (kein Fehler,
+		keine Löschung).
+	*/
+	public function testDeleteNonexistentTodoDoesNothing(){
+		$userId = 1;
+		$title = 'Ein Todo';
+		
+		//	Ein Todo anlegen
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userId, $title]);
+		
+		$nonExistentTodoId = 999;
+		//	Es darf keine Exception auftreten
+		deleteTodo($this->pdo, $userId, $nonExistentTodoId);
+		
+		//	Prüfen, dass es keine Todos gibt
+		$stmt = $this->pdo->prepare("select count(*) from todos");
+		$stmt->execute();
+		$count = $stmt->fetchColumn();
+		$this->assertEquals(1, $count);
+	}
+	
+	/*
+		Test Nr. 4
+		Ein Todo mit gültiger ID darf nicht gelöscht werden, wenn die
+		Benutzer-ID nicht existiert.
+	*/
+	public function testDeleteTodoWithInvalidUserIdDoesNothing(){
+		$validUserId = 1;
+		$invalidUserId = 2;
+		$title = 'Ein Todo';
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$validUserId, $title]);
+		$todoId = $this->pdo->lastInsertId();
+		
+		deleteTodo($this->pdo, $invalidUserId, $todoId);
+		
+		$stmt = $this->pdo->prepare("select count(*) from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$count = $stmt->fetchColumn();
+		
+		$this->assertEquals(1, $count);
+	}
+}

--- a/projekt/tests/todo/GetTodosByUserTest.php
+++ b/projekt/tests/todo/GetTodosByUserTest.php
@@ -1,0 +1,132 @@
+<?php
+//	funktionen_tests.php
+use PHPUnit\Framework\TestCase;
+	
+require_once __DIR__ . '/../todo.php';
+require_once __DIR__ . '/../db.php';
+	
+//	Testklasse für getTodosByUser()
+class GetTodosByUserTest extends TestCase
+{
+	private PDO $pdo;
+	
+	protected function setUp(): void{
+		$this->pdo = new PDO("sqlite::memory:");
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		
+		//	Benutzer- und Todos-Tabelle erstellen
+		$this->pdo->exec("
+			create table users(
+				id int AUTO_INCREMENT primary key,
+				email varchar(255) unique not null,
+				password varchar(255) not null,
+				created_at timestamp default current_timestamp
+			);
+		");
+		
+		$this->pdo->exec("
+			create table todos(
+				id int auto_increment primary key,
+				user_id int not null,
+				title varchar(255) not null,
+				is_done boolean default false,
+				created_at timestamp default current_timestamp,
+				foreign key (user_id) references users(id) on delete cascade
+			);
+		");
+		
+		$stmt = $this->pdo->prepare("insert into users (email, password) values (?, ?)");
+		$stmt->execute(['test@test.de', password_hash('EinPasswort123-', PASSWORD_DEFAULT)]);
+	}
+
+	/*
+		Test Nr. 1
+		Dieser Test ruft alle Todos eines Nutzers ab.
+		Einem per setUp() erstellten Nutzer wird ein Todo hinzufegüt.
+		Dieses wir aus der DB per getTodosByUser() abgerufen.
+		Der Test muss alle hinzugefügten Daten erfolgreich abrufen können.
+	*/
+	public function testGetTodosByUser(){
+		/*
+			Testbenutzer ID holen (wir gehen davon aus, dass der Benutzer als
+			Erster eingefügt wurde)
+		*/
+		$userId = 1;
+		$todoName = 'Neues Todo';
+		
+		//	Ein Todo hinzufügen
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userId, $todoName]);
+		
+		//	Todos für den Benutzer abfragen
+		$todos = getTodosByUser($this->pdo, $userId);
+		
+		$this->assertCount(1, $todos);
+		$this->assertEquals('Neues Todo', $todos[0]['title']);
+		$this->assertEquals(0, $todos[0]['is_done']);
+	}
+	
+	/*
+		Test Nr. 2
+		Dieser Test prüft die Abfrage:
+		-	Nutzer hat keine Todos
+		Entsprechend sollte die DB keine Einträge zurückgeben
+	*/
+	public function testGetTodosByUserReturnsEmptyArrayWhenNoTodosExist(){
+		$userId = 1;
+		$todos = getTodosByUser($this->pdo, $userId);
+		$this->assertIsArray($todos);
+		$this->assertCount(0, $todos);
+	}
+	
+	/*
+		Test Nr. 3
+		Dieser Test prüft die Abfrage:
+		-	Nutzer hat mehrere Todos
+		Die DB muss meherere Einträge zurückliefern
+	*/
+	public function testGetTodosByUserReturnsMultipleTodos(){
+		$userId = 1;
+		$titleArr = array(
+			"title1"	=>	"Eintrag Nr. 1",
+			"title2"	=>	"Eintrag Nr. 2",
+		);
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userId, $titleArr['title1']]);
+		$stmt->execute([$userId, $titleArr['title2']]);
+		
+		$todos = getTodosByUser($this->pdo, $userId);
+		$this->assertCount(2, $todos);
+		$this->assertEquals('Eintrag Nr. 1', $todos[0]['title']);
+		$this->assertEquals('Eintrag Nr. 2', $todos[1]['title']);
+	}
+	
+	/*
+		Test Nr. 4
+		Dieser Test soll sicherstellen, dass exakt die Todos ausgegeben werden,
+		die zum angegebenen Benutzer gehören (welchen wir per userId angeben)
+	*/
+	public function testGetTodosByUserIgnoresTodosOfOtherUsers(){
+		//	Weiteren Benutzer in die DB einfügen
+		$email = 'test@asdfjl.de';
+		$password = 'Msdiufh-23a';
+		
+		$stmt = $this->pdo->prepare("insert into users (email, password) values (?, ?)");
+		$stmt->execute([$email, $password]);
+		
+		$userOne = 1;
+		$titleOne = 'Ein Todo';
+		
+		$userTwo = 2;
+		$titleTwo = 'Zwei Todo';
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title) values (?, ?)");
+		$stmt->execute([$userOne, $titleOne]);
+		$stmt->execute([$userTwo, $titleTwo]);
+		
+		$todos = getTodosByUser($this->pdo, $userOne);
+		$this->assertCount(1, $todos);
+		$this->assertEquals('Ein Todo', $todos[0]['title']);
+	}
+}

--- a/projekt/tests/todo/ToggleTodoTest.php
+++ b/projekt/tests/todo/ToggleTodoTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+	Sollten noch globale Variablen vor Tests geleert?
+	Gilt für alle Todo-Funktionen
+*/
+
+//	funktionen_tests.php
+use PHPUnit\Framework\TestCase;
+	
+require_once __DIR__ . '/../todo.php';
+require_once __DIR__ . '/../db.php';
+	
+//	Testklasse für toggleTodo()
+class ToggleTodoTest extends TestCase
+{
+	private PDO $pdo;
+	
+	protected function setUp(): void{
+		$this->pdo = new PDO("sqlite::memory:");
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$this->pdo->exec('pragma foreign_keys = on');
+		
+		//	Benutzer- und Todos-Tabelle erstellen
+		$this->pdo->exec("
+			create table users(
+				id integer primary key autoincrement,
+				email varchar(255) unique not null,
+				password varchar(255) not null,
+				created_at timestamp default current_timestamp
+			);
+		");
+		
+		$this->pdo->exec("
+			create table todos(
+				id integer primary key autoincrement,
+				user_id int not null,
+				title varchar(255) not null,
+				is_done boolean default false,
+				created_at timestamp default current_timestamp,
+				foreign key (user_id) references users(id) on delete cascade
+			);
+		");
+		
+		$stmt = $this->pdo->prepare("insert into users (email, password) values (?, ?)");
+		$stmt->execute(['test@test.de', password_hash('EinPasswort123-', PASSWORD_DEFAULT)]);
+	}
+
+	/*
+		Test Nr. 1
+		Hier wird geprüft, ob der Todo-Status, durch auslösen der
+		toggleTodo()-Funktion, korrekt angepasst wird - Von false zu true.
+	*/
+	public function testToggleTodoSetsIsDoneToTrue(){
+		$userId = 1;
+		$title = 'Ein Todo';
+		
+		//	Todo anlegen
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title, is_done) values (?, ?, ?)");
+		$stmt->execute([$userId, $title, false]);
+		
+		$todoId = $this->pdo->lastInsertId();
+		
+		//	Toggle
+		toggleTodo($this->pdo, $userId, $todoId);
+		
+		//	Prüfen
+		$stmt = $this->pdo->prepare("select is_done from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$isDone = $stmt->fetchColumn();
+		
+		$this->assertEquals(1, $isDone);
+	}
+	
+	/*
+		Test Nr. 2
+		Hier wird geprüft, ob der Todo-Status, durch auslösen der
+		toggleTodo()-Funktion, korrekt angepasst wird - Von true zu false.
+	*/
+	public function testToggleTodoSetsIsDoneToFalse(){
+		$userId = 1;
+		$title = 'Ein Todo';
+		
+		//	Todo anlegen
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title, is_done) values (?, ?, ?)");
+		$stmt->execute([$userId, $title, true]);
+		
+		$todoId = $this->pdo->lastInsertId();
+		
+		//	Toggle
+		toggleTodo($this->pdo, $userId, $todoId);
+		
+		//	Prüfen
+		$stmt = $this->pdo->prepare("select is_done from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$isDone = $stmt->fetchColumn();
+		
+		$this->assertEquals(0, $isDone);
+	}
+	
+	/*
+		Test Nr. 3
+		Hier testen wir das Verhalten der Funktion dahingehend, dass ein Todo
+		erst über eine User-ID angelegt wird und anschließend probiert wird,
+		diesen Eintrag über eine andere User-ID zu manipulieren.
+		
+		Die Manipulation des Statuses darf nicht klappen.
+	*/
+	public function testToggleTodoWithWrongUserDoesNotAffectTodo(){
+		$userId = 1;
+		$wrongUserId = 2;
+		$title = 'Fremdes Todo';
+		
+		//	Todo mit userId = 1 anlegen
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title, is_done) values (?, ?, ?)");
+		$stmt->execute([$userId, $title, false]);
+		$todoId = $this->pdo->lastInsertId();
+		
+		//	Probieren Toggle mit falscher Benutzer-ID auszulösen
+		toggleTodo($this->pdo, $wrongUserId, $todoId);
+		
+		$stmt = $this->pdo->prepare("select is_done from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$isDone = $stmt->fetchColumn();
+		
+		$this->assertEquals(0, (int)$isDone);
+	}
+	
+	/*
+		Test Nr. 4
+		Hier testen wir, wie sich die Funktion verhält, wenn eine ungültige
+		Todo-ID an sie übergeben wird. Es darf kein Todo zurückgeliefert werden.
+		Bzw. muss die Spalte / DB-Eintrag leer sein.
+	*/
+	public function testToggleTodoWithInvalidTodoIdDoesNothing(){
+		$userId = 1;
+		$invalidTodoId = 999;
+		
+		//	Kein Eintrag vorhanden
+		//	Sollte ohne Exception laufen
+		toggleTodo($this->pdo, $userId, $invalidTodoId);
+		
+		//	Prüfen ob die Tabelle leer bleibt
+		$stmt = $this->pdo->query("select count(*) from todos");
+		$count = $stmt->fetchColumn();
+		
+		$this->assertEquals(0, $count);
+	}
+	
+	/*
+		Test Nr. 5
+		In diesem Test wird sichergestellt, dass ein Todo-Eintrag nicht verändert
+		wird, wenn versucht wird, ihn mit einer nicht existierenden Benutzer-ID
+		umzuschalten.
+		
+		Unterschied zu Test Nr. 3:
+		Dort prüfen wir, dass Benutzer keinen Zugriff auf Todo-Listen anderer
+		(nicht ihrer eigenen) Benutzer erhalten.
+		
+		Hier hingegen geht es darum, dass eine völlig ungültige (nicht vorhandene)
+		Benutzer-ID ebenfalls keinen Einfluss auf bestehende Todos haben darf.
+	*/
+	public function testToggleTodoWithInvalidUserIdDoesNothing(){
+		//	Gültiger Todo
+		$validUserId = 1;
+		$invalidUserId = 999;
+		$title = 'Todo';
+		
+		$stmt = $this->pdo->prepare("insert into todos (user_id, title, is_done) values (?, ?, ?)");
+		$stmt->execute([$validUserId, $title, false]);
+		$todoId = $this->pdo->lastInsertId();
+		
+		//	Toggle versuchen mit ungültigem Benutzer
+		toggleTodo($this->pdo, $invalidUserId, $todoId);
+		
+		//	Prüfen, ob Todo unverändert ist
+		$stmt = $this->pdo->prepare("select is_done from todos where id = ?");
+		$stmt->execute([$todoId]);
+		$isDone = $stmt->fetchColumn();
+		
+		$this->assertEquals(0, (int)$isDone);
+	}
+}


### PR DESCRIPTION
### Hintergrund

<!-- Beschreibe kurz den Kontext des PRs.
Was ist der technische oder fachliche Hintergrund?
Warum wird diese Änderung benötigt? -->

Dieser PR integriert PHPUnit-basierte Tests für die Benutzer-Authentifizierung
aus einer früheren Version der Anwendung. Die Tests decken zentrale Funktionen
wie `createUser`, `isValidPassword` oder `isEmailRegistered` ab und wurden
urspruenglich erfolgreich ausgefuehrt.

Mit der aktuellen Umstellung auf eine containerisierte API-Architektur (z.B.
durch Einsatz von JWT und Endpunkt-basierten Ablaeufen) sind diese Tests
**nicht mehr direkt kompatibel**.

---

### Änderungen im Detail

<!-- Liste die konkreten Änderungen auf.
Was wurde hinzugefügt, entfernt oder angepasst? -->

- `tests/auth/`: 5 vollstaendige Testklassen zur Authentifizierungslogik
- Struktur und Assertions basieren auf PHPUnit

---

### Ziel / Zweck des PRs

<!-- Was soll mit diesem PR erreicht werden?
Was ist das gewünschte Ergebnis? -->

- Vorhandene Testbasis archivieren und transparent dokumentieren
- Ausgangspunkt für spaetere Migration zu einer neuen Teststruktur schaffen
- Codequalitaet des bisherigen Standes nachvollziehbar machen

---

### Hinweise für Reviewer:innen

<!-- Gibt es etwas Besonderes zu beachten?
Technische Schulden, Abhängigkeiten, bekannte Einschränkungen? -->

- Tests sind **nicht auf aktuelle API-Endpunkte abgestimmt**
- Kein aktiver Testlauf vorgesehen
- Einige Testmethoden beziehen sich auf Methoden, die strukturell veraendert oder verschoben wurden

---

### Folgeänderungen (optional)

<!-- Falls dieser PR Teil eines größeren Tasks oder Refactors ist,
was kommt danach? -->

- [ ] Refactor der Teststruktur auf containerisierte Umgebung