### PR TITLE
docs(issues/templates): add issue template for planned tasks (classic…

### DIFF
--- a/.github/ISSUE_TEMPLATE/geplantes-issue.yml
+++ b/.github/ISSUE_TEMPLATE/geplantes-issue.yml
@@ -1,0 +1,49 @@
+name: Geplantes Issue (klassischer Workflow)
+description: Planung einer technischen Aufgabe oder Verbesserung vor Umsetzung
+title: "[Planung]: <Kurzbeschreibung der Aufgabe>"
+labels: ["planning", "todo"]
+body:
+  - type: textarea
+    id: ziel
+    attributes:
+      label: Ziel
+      description: Was soll erreicht werden? (fachlich/technisch)
+      placeholder: z.B. "Der Benutzer soll Todos nach Status filtern koennen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: kontext
+    attributes:
+      label: Hintergrund / Kontext
+      description: Warum ist das relevant? Wo tritt das Problem oder der Bedarf auf?
+      placeholder: z.B. "Das Dashboard zeigt aktuell alle Todos ungefiltert. Nutzer wuenschen sich mehr Uebersicht."
+    validations:
+      required: true
+
+  - type: textarea
+    id: vorschlag
+    attributes:
+      label: Loesungsansatz / Umsetzungsidee
+      description: Wie koennte das technisch umgesetzt werden?
+      placeholder: z.B. "Frontend: Dropdown zur Auswahl des Status. API: optionaler Filter-Parameter ?status=..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: test
+    attributes:
+      label: Testhinweise (optional)
+      description: Wie kann spaeter ueberprueft werden, ob die Aufgabe erfuellt ist?
+      placeholder: z.B. "UI zeigt nach Auswahl im Dropdown nur Todos mit entsprechendem Status."
+    validations:
+      required: false
+
+  - type: textarea
+    id: sonstiges
+    attributes:
+      label: Weitere Hinweise (optional)
+      description: Abhaengigkeiten, bekannte Probleme, Refactoringbedarf etc.
+      placeholder: z.B. "API-Aenderungen koennten andere Module beeinflussen."
+    validations:
+      required: false


### PR DESCRIPTION
### Hintergrund

Der bisherige Issue-Workflow wurde rückblickend über PRs abgebildet. Für
zukünftige Aufgaben soll der klassische Entwicklungsablauf unterstützt werden:
Issue (Planung) -> PR -> closes #... -> Merge.

Ein strukturiertes YAML-Issue-Template erleichtert die Planung und
Dokumentation technischer Aufgaben vor der Umsetzung.

---

### Änderungen im Detail

- Neues .yml-Issue-Template hinzugefügt: geplantes-issue.yml
- Felder: Ziel, Kontext, Lösungsansatz, Tests, Hinweise
- Labels automatisch gesetzt: planning, todo
- Template unterstützt die Strukturierung des klassischen Entwicklungsworkflows

---

### Ziel / Zweck des PRs

Einführung eines nutzerfreundlichen Templates zur Planung von Aufgaben vor der
Umsetzung, um saubere, nachvollziehbare PR-Referenzen (closes #...) und ein
klar strukturiertes Kanban-Board zu ermöglichen.

---

### Testhinweise

- Nach dem Merge: Neues Issue über „New issue“ erstellen -> „Geplantes Issue (klassischer Workflow)“ auswählen
- Felder prüfen (Pflichtfelder, Labels, Titelvorschlag)
- Test-Issue erstellen, um Darstellung zu validieren

---

### Hinweise für Reviewer

- Keine Code-Änderungen - rein dokumentationsbezogen
- Das Template greift ausschließlich auf der GitHub-Oberfläche beim Erstellen neuer Issues
- Funktioniert wie andere .yml-basierten Templates für Issues (nicht PRs)