### PR TITLE
docs(readme): update Docker and Compose versions for Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Aktuell basiert **WebStart** auf folgenden Komponenten:
 - **Composer**: 2.8.8 ─ zur Verwaltung von PHP-Abhaengigkeiten
 - **MariaDB**: 10.11 ─ relationale Datenbank
 - **phpMyAdmin**: 5.2.1
-- **Docker Engine**: 27.2.0 (Docker ueber Docker Desktop unter Windows)
-- **Docker Compose**: 2.29.2-desktop.2 - zur Container-Orchestrierung
+- **Docker**: 27.5.1 (getestet unter Ubuntu 24.04)
+- **Docker Compose**: 2.36.2 (CLI integriert, `docker compose`)
 
 ## 2. Projektstruktur
 


### PR DESCRIPTION
### Hintergrund

Die ursprüngliche README enthielt Angaben zu Docker und Docker Compose, die auf Windows (Docker Desktop) basierten. Da das Projekt nun unter Ubuntu 24.04 weiterentwickelt und getestet wird, mussten die Versionsangaben sowie die Begriffe entsprechend angepasst werden, um Konsistenz und Korrektheit für Linux-Nutzer sicherzustellen.

---

### Änderungen im Detail

- Aktualisierung der Docker-Version auf 27.5.1 (Ubuntu)
- Aktualisierung der Docker Compose-Version auf 2.36.2 (CLI-basiert)
- Ergänzung von Plattform-Hinweisen im Technologie-Stack der README

---

### Ziel / Zweck des PRs

- README soll den aktuellen Entwicklungsstand unter Ubuntu widerspiegeln
- Missverständnisse bei Plattformunterschieden vermeiden
