### PR TITLE
refactor(app/dockerfile): switch to dev mode with bind mounts and run…

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,8 +1,10 @@
+# DEV - Version
+
 # Debian + Apache + PHP - Docker Hub
 FROM php:8.2-apache
 
 # Arbeitsverzeichnis setzen
-WORKDIR /var/www/app
+# WORKDIR /var/www/app
 
 # Projekt kopieren
 COPY ./projekt /var/www/app
@@ -39,4 +41,4 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
 	mv composer.phar /usr/local/bin/composer
 
 # Composer-Abhaengigkeiten installieren
-RUN composer install
+# RUN composer install


### PR DESCRIPTION
### Hintergrund

Im Rahmen der Umstrukturierung der Docker-Konfigurationen wurde bereits die
zentrale Ablage unter /docker/app/ etabliert. Bisher nutzte das Dockerfile
einen Build-basierten Ansatz mit COPY und composer install zur Build-Zeit. Für
die lokale Entwicklung ist jedoch ein dynamischer Ansatz mit Bind-Mounts und
Composer-Ausführung zur Laufzeit geeigneter.

Diese Änderung verbessert die Entwicklungsfreundlichkeit und reduziert unnötige
Container-Neubauten bei Änderungen im Code.

---

### Änderungen im Detail

- Entfernen von COPY ./projekt aus dem Dockerfile (wird über Volume eingebunden)
- Entfernen von RUN composer install (Composer wird stattdessen zur Laufzeit via command: in docker-compose.yml ausgeführt)
- Entsprechende Kommentare eingefügt, um den DEV-Kontext kenntlich zu machen

---

### Ziel / Zweck des PRs

- Das Dockerfile an die Anforderungen für lokale Entwicklungsumgebungen anpassen
- Aufbauzeit des Containers verkürzen
- Bessere Nutzung von Volume-Mounts

---

### Testhinweise

- Docker-Container über docker compose -f docker/app/docker-compose.yml up --build starten
- Sicherstellen, dass beim Start:
 - vendor/-Ordner erzeugt wird
 - die Anwendung unter http://localhost:8080 erreichbar ist
- Änderungen im Projektverzeichnis (projekt/) sollten sofort im Container wirksam sein (Bind-Mount)

---

### Hinweise für Reviewer

- Dockerfile ist nun bewusst auf lokale Entwicklung optimiert
- Für Produktion ist ein separates Dockerfile oder eine Build-Variante sinnvoll

---

### Folgeänderungen

- [ ] Anlegen eines separaten Dockerfile.prod für produktives Build-Image
- [ ] Dokumentation im README.md zur Nutzung von DEV/PROD-Setups ergänzen
