### PR TITLE
fix(docker/app): adjust command in docker-compose-file

### DIFF
--- a/docker/app/docker-compose.yml
+++ b/docker/app/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         #Führt bei jedem Containerstart Composer aus, damit der
         #vendor/-Ordner im gemounteten Volume verfügbar ist
         #apache2-foreground startet danach den Apache-Prozess wie üblich
-        command: sh -c "composer install && apache2-foreground"
+        command: sh -c "cd /var/www/app && composer install && apache2-foreground"
         #Sicherheitsfeature fuer Production
         #cap_drop:
             #- ALL


### PR DESCRIPTION
### Hintergrund

Beim Starten des Apache-PHP-Containers schlug der composer install-Befehl fehl, da er im falschen Arbeitsverzeichnis ausgeführt wurde. Composer konnte daher keine composer.json-Datei finden. Das Setup ist für lokale Entwicklung gedacht, bei der Composer-Abhängigkeiten automatisch installiert werden sollen.

---

### Änderungen im Detail

- command in docker-compose.yml angepasst: composer install wird nun im korrekten Verzeichnis /var/www/app ausgeführt
- Sicherstellung, dass das Projektverzeichnis composer.json enthält und korrekt verwendet wird

---

### Ziel / Zweck des PRs

Der Container startet nun erfolgreich, Composer findet die Konfigurationsdatei, und die Abhängigkeiten werden wie erwartet installiert. Dies ermöglicht einen funktionierenden lokalen Entwicklungsworkflow.

---

### Testhinweise

- docker compose -f docker/app/docker-compose.yml up --build ausführen
- Prüfen, ob vendor/ im Projektverzeichnis erstellt wird
- Kein Fehler bzgl. fehlender composer.json sollte mehr auftreten
- Projekt unter http://localhost:8080/ aufrufen

---

### Hinweise für Reviewer

- Die Änderung betrifft nur die lokale Entwicklungsumgebung