### PR TITLE
Feat/phpdoc setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,19 @@ WebStart/
 │
 ├── docker/
 │    ├─── documentation/
-│    │    └─── jsdoc/
+│    │    ├─── jsdoc/
+│    │    │    ├─── docker-compose.yml
+│    │    │    ├─── docker-compose.tooling.yml
+│    │    │    ├─── jsdoc-runner.dockerfile
+│    │    │    ├─── jsdoc-web.dockerfile
+│    │    │    ├─── out/
+│    │    │    └─── .jsdoc-tooling/
+│    │    │         └─── jsdoc.json
+│    │    │
+│    │    └─── phpdoc/
 │    │         ├─── docker-compose.yml
-│    │         ├─── docker-compose.tooling.yml
-│    │         ├─── jsdoc-runner.dockerfile
-│    │         ├─── jsdoc-web.dockerfile
-│    │         ├─── out/
-│    │         └─── .jsdoc-tooling/
-│    │              └─── jsdoc.json
+│    │         ├─── phpdoc.dist.xml
+│    │         └─── out/
 │    │
 │    └─── app/
 │         ├─── docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ lassen.
 6. [Projektstart & Nutzung](#6-projektstart--nutzung)
 	- [6.1 Wichtiger Hinweis zur Erstinitialisierung](#61-wichtiger-hinweis-zur-erstinitialisierung)
 	- [6.2 JavaScript-Dokumentation (JSDoc) erzeugen und anzeigen](#62-javascript-dokumentation-jsdoc-erzeugen-und-anzeigen)
+	- [6.3 PHP-Dokumentation (PHPDoc) erzeugen und anzeigen](#63-php-dokumentation-phpdoc-erzeugen-und-anzeigen)
 7. [Datenbankstruktur](#7-datenbankstruktur)
 8. [Tests](#8-tests)
 9. [Lizenzen der verwendeten Technologien](#9-lizenzen-der-verwendeten-technologien)
@@ -355,6 +356,50 @@ Dies erzeugt im Verzeichnis .jsdoc-tooling/ die Dateien package.json und package
 
 Aufruf im Browser:\
 [http://localhost:8081](http://localhost:8081)
+
+### 6.3 PHP-Dokumentation (PHPDoc) erzeugen und anzeigen
+
+Zur Dokumentation des PHP-Codes wird [phpDocumentor](https://www.phpdoc.org/) verwendet.\
+Die Generierung erfolgt über ein separates Docker-Setup, das unabhängig von der Hauptanwendung\
+betrieben wird.
+
+#### Dokumentation generieren
+
+In folgendes Verzeichnis wechseln:\
+`WebStart/docker/documentation/phpdoc/`
+
+Anschliessend zuerst den PHPDoc-Service der `docker-compose.yml` aufrufen:\
+`docker compose run --rm phpdoc`
+
+Dies analysiert den PHP-Code gemäß Konfiguration und erzeugt die HTML-Dokumentation im\
+Unterordner out/.
+
+#### Dokumentation im Browser anzeigen
+
+In einem zweiten Schritt kann die nun vorhandene Dokumentation, per Apache-Container
+gestartet werden:\
+`docker compose up apache`
+
+Aufruf im Browser:\
+[http://localhost:8080](http://localhost:8080)
+
+**Hinweis**\
+Der Ordner `out/` wird per Volume in den Apache-Container eingebunden und dient dort als\
+Webroot.
+
+#### PHPDoc - Konfigurationsdatei
+
+Die Konfigurationsdatei `phpdoc.dist.xml` befindet sich im Verzeichnis:\
+`WebStart/docker/documentation/phpdoc/phpdoc.dist.xml`
+
+Diese enthält u.a.:
+- Ausgabeordner: `out/`
+- Cache-Verzeichnis: `cache/`
+- Eingelesene Quellverzeichnisse:
+ 1. `projekt/src/auth`
+ 2. `projekt/src/core`
+ 3. `projekt/src/todo`
+ 4. `projekt/public/api`
 
 #### Datenbank vollständig zurücksetzen:
 

--- a/docker/documentation/phpdoc/docker-compose.yml
+++ b/docker/documentation/phpdoc/docker-compose.yml
@@ -1,0 +1,21 @@
+# Gezielt die einzelnen Services starten:
+# 1. sicherstellen, dass die gesamte Doku geladen ist: docker compose run --rm phpdoc
+# 2. Webserver starten, sobald Doku generiert in out vorliegt: docker compose up apache
+version: "3.9"
+
+services:
+  phpdoc:
+    image: phpdoc/phpdoc:3
+    volumes:
+      - .:/data
+      - ../../../projekt:/projekt
+    command: -c /data/phpdoc.dist.xml
+
+  apache:
+    image: httpd:2.4
+    ports:
+      - "8080:80"
+    volumes:
+      - ./out:/usr/local/apache2/htdocs:ro
+    depends_on:
+      - phpdoc

--- a/docker/documentation/phpdoc/phpdoc.dist.xml
+++ b/docker/documentation/phpdoc/phpdoc.dist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+    configVersion="3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://www.phpdoc.org"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/phpDocumentor/phpDocumentor/master/data/xsd/phpdoc.xsd"
+>
+
+    <title>phpDocumentor</title>
+
+    <paths>
+        <output>out</output>
+        <cache>cache</cache>
+    </paths>
+
+    <version number="3.0.0">
+        <api>
+            <source dsn="./../../../projekt">
+                <path>src/auth</path>
+                <path>src/core</path>
+		<path>public/api</path>
+                <path>src/todo</path>
+            </source>
+
+            <ignore>
+                <path>vendor/**/*</path>
+            </ignore>
+
+            <extensions>
+                <extension>php</extension>
+            </extensions>
+        </api>
+    </version>
+</phpdocumentor>


### PR DESCRIPTION
### Hintergrund

Das Projekt soll eine Dokumentation für den PHP-Code bekommen, so wie es für JavaScript mit JSDoc bereits gelöst ist.
Die Idee ist, PHPDoc zu verwenden und das Ganze mit Docker umzusetzen, damit es einfach und überall gleich funktioniert.

---

### Änderungen im Detail

- Neuer Ordner: docker/documentation/phpdoc/
 - Enthält phpdoc.dist.xml für die Konfiguration
 - Enthält docker-compose.yml zum Starten der Doku-Erstellung und Webansicht
- README.md erweitert:
 - Neuer Abschnitt „6.3 PHP-Dokumentation (PHPDoc)“
 - Anleitung zum Erstellen und Anzeigen der Doku

---

### Ziel / Zweck des PRs

Ein Docker-basiertes Setup, mit dem man den PHP-Code dokumentieren und die Doku direkt im Browser ansehen kann.

---

### Testhinweise

1. In das Verzeichnis docker/documentation/phpdoc/ wechseln
2. PHPDoc starten:\
`docker compose run --rm phpdoc`
3. Danach die Webansicht starten:\
`docker compose up apache`
4. Im Browser aufrufen:
[http://localhost:8080](http://localhost:8080)
---

### Hinweise für Reviewer

- Die Konfiguration (phpdoc.dist.xml) gibt an, welche Ordner im Projekt dokumentiert werden sollen.
- Die Dokumentation wird im Ordner out/ abgelegt.
- Der Apache-Container zeigt diese Doku im Browser an.
- Setup ist unabhängig vom Hauptprojekt.