### PR TITLE
Docs/add jsdoc frontend comments

### DIFF
--- a/projekt/public/js/dashboard/dom/create.js
+++ b/projekt/public/js/dashboard/dom/create.js
@@ -1,6 +1,18 @@
 import {createTextElement} from "./../../shared/dom/elements.js"
 
-// Erzeugt die leere Todo-Nachricht (z.B. wenn keine Todos vorhanden sind)
+/**
+ * @typedef {Object} TodoItem
+ * @property {number} todo_id - Die eindeutige ID des Todos.
+ * @property {string} todo_title - Der Titel des Todos.
+ * @property {number} todo_status - 1 fuer erledigt, 0 fuer offen.
+ * @property {string} todo_iat - Zeitstempel der Erstellung (ISO-Format).
+ */
+
+/**
+ * Erzeugt Todo-Nachricht fuer leere Todo-Liste
+ *
+ * @returns {HTMLLiElement} Li-Element mit eingegebenem Textinhalt
+ */
 export function createEmptyTodoMessage(){
 	const li = createTextElement("li", "Nothing to do - Relax");
 	li.dataset.empty = "true";
@@ -8,60 +20,90 @@ export function createEmptyTodoMessage(){
 	return li;
 }
 
-/*
- Erzeugt ein vollstaendiges Listenelement fuer ein Todo
- {onToggle, onDelete}: Eventhandler, die beim Statuswechsel oder
- Loeschen aufgerufen werden
-*/
-
+/**
+ * Erzeugt einen vollstaendigen Eintrag fuer die Todo-Liste
+ * 
+ * @param {TodoItem} todo - Ein einzelnes Todo-Objekt aus der API.
+ * @param {{
+ *    onToggle: function(number): void,
+ *    onDelete: function(number): void
+ *  }} callbacks
+ * @returns {HTMLLiElement} Der vollstaendige Eintrag fuer die Todo-Liste
+ */
 export function createTodoListItem(todo, {onToggle, onDelete}){
 	// Container <li> und inneres <div>
+	/**
+	 * Erstellen des Listeneintrags, welcher angehaengt wird
+	 * Erstellen eines Containers, in welchen die Todo-Elemente eingefuegt werden
+	 */
 	const li = document.createElement("li");
 	const textDiv = document.createElement("div");
 	
+	/**
+	 * Jedem Todo wird eine ID hinzugefuegt
+	 */
 	li.dataset.id = todo?.todo_id;
 	
-	// Todo-Titel <h3>
+	/**
+	 * Erstellen des Titels fuer ein Todo
+	 */
 	const todoTitle = createTextElement("h3", (todo?.todo_title ?? "No title"));
 	
-	// Checkbox zur Statusanzeige/-aenderung
+	/**
+	 * Statusanzeige eines Todos
+	 */
 	const todoCheckbox = document.createElement("input");
 	todoCheckbox.type = "checkbox";
 	todoCheckbox.dataset.id = todo?.todo_id;
 	todoCheckbox.checked = todo?.todo_status == 1;
-	
-	// Label fuer die Checkbox mit Status-Text
+
+	/**
+	 * Klickbares Label fuer die Statusanzeige eines Todos
+	 */
 	const checkboxLabel = document.createElement("label");
 	checkboxLabel.appendChild(todoCheckbox);
 	checkboxLabel.appendChild(
 		document.createTextNode(todo?.todo_status == 1 ? " Done" : " In progress")
 	);
 	
-	// Zeitstempel <h4>
+	/**
+	 * Erstellungsdatum des Todos
+	 */
 	const todoIat = createTextElement("h4", (todo?.todo_iat ?? "No date"));
 	
-	// Delete-Button
+	/**
+	 * Button zum Loeschen eines Todos
+	 */
 	const deleteButton = document.createElement("button");
 	deleteButton.textContent = "Delete";
 	deleteButton.dataset.id = todo?.todo_id;
 	
-	// Alles ins Text-Div einhaengen
+	/**
+	 * Alle Komponenten eines Todos im Container buendeln
+	 */
 	textDiv.appendChild(todoTitle);
 	textDiv.appendChild(checkboxLabel);
 	textDiv.appendChild(todoIat);
 	textDiv.appendChild(deleteButton);
 	
-	// Div in das Listen-Element einhaengen
+	/**
+	 * Container mit gebuendelten Todo-Komponenten in die Todo-Liste einhaengen
+	 */
 	li.appendChild(textDiv);
 	
-	// Eventhandler binden, nur wenn todo_id existiert
+	/**
+	 * Eventhandler fuer Todo-Statusanzeige
+	 */
 	if(todo?.todo_id){
-		// Beim Statuswechsel die uebergebene Callback-Funktion onToggle ausfuehren
+		/**
+		 * Todo-Statuswechsel-Callback - Done oder In progress
+		 */
 		todoCheckbox.addEventListener("change", () => onToggle(todo.todo_id));
-		// Beim Klick auf "Delete" die uebergebene Callback-Funktion onDelete ausfuehren
+		/**
+		 * Todos-Loeschen-Callback
+		 */
 		deleteButton.addEventListener("click", () => onDelete(todo.todo_id));
 	}
 	
-	// Rueckgabe des vollstaendigen Listenelements <li>
 	return li;
 }

--- a/projekt/public/js/dashboard/dom/selectors.js
+++ b/projekt/public/js/dashboard/dom/selectors.js
@@ -1,14 +1,36 @@
+/**
+ * Enthaelt alle DOM-Elemente fuer das Dashboard.
+ * @type {Object.<string, HTMLElement>}
+ */ 
 export const dashboardSelectors = {
-	// Wilkommensnachricht
+	/**
+	 * Eine Wilkommensnachricht als Ueberschrift.
+	 * @type {HTMLHeadingElement}
+	 */
 	welcomeMessageH1: document.getElementById("userWelcome"),
-	// Todoeintraege der Todoliste, wenn Eintraege vorhanden
+	/**
+	 * Eintraege der Todoliste, wenn vorhanden.
+	 * @type {HTMLUListElement}
+	 */
 	todoRecordUl: document.getElementById("todoRecord"),
-	// Formular - Hinzufuegen von Todos
+	/**
+	 * Formular zum Hinzufuegen von Todos.
+	 * @type {HTMLFormElement}
+	 */
 	addTodoForm: document.getElementById("addTodoForm"),
-	// Infobox - Statusausgabe nachdem ein Todo hinzugefuegt wurde
+	/**
+	 * Infobox, Statusausgabe nach Todohinzufuegen.
+	 * @type {HTMLParagraphElement}
+	 */
 	messageAddTodo: document.getElementById("messageAddTodo"),
-	// Ueberschrift zu den Todos
+	/**
+	 * Ueberschrift der Todos.
+	 * @type {HTMLHeadingElement}
+	 */
 	ulHeaderH2: document.getElementById("ulHeader"),
-	// Input - Eingabefeld, in welches der Todotitel eingegeben wird
+	/**
+	 * Eingabefeld fuer den Titel neuer Todos.
+	 * @type {HTMLInputElement}
+	 */
 	newTodoTitle: document.getElementById("title")
 };

--- a/projekt/public/js/dashboard/events/dashboardEvents.js
+++ b/projekt/public/js/dashboard/events/dashboardEvents.js
@@ -1,14 +1,71 @@
+/**
+ * Liefert ein HTMLInputElement zur Eingabe des Todo-Titels.
+ *
+ * @callback GetInputCallback
+ * @returns {HTMLInputElement}
+ */
+
+/**
+ * Zeigt eine Nachricht im Dashboard an.
+ *
+ * @callback ShowMessageCallback
+ * @param {string} message - Die anzuzeigende Nachricht.
+ */
+
+/**
+ * Fuegt ein neues Todo hinzu.
+ *
+ * @callback AddTodoCallback
+ * @param {string} title - Der Titel des neuen Todos.
+ * @returns {Promise<{success: boolean, message?: string}>}
+ */
+
+/**
+ * Uebernimmt das Event-Handling beim Hinzufuegen eines neuen Todos.
+ *
+ * @param {{
+ *    onAddTodo: AddTodoCallback,
+ *    getInput: GetInputCallback,
+ *    showMessage: ShowMessageCallback
+ * }} callbacks - Alle noetigen Funktionen zur Formularverarbeitung
+ */
 export function registerDashboardEvents({
+	/**
+	 * Callback-Funktionen zur Interaktion mit der Anwendung
+	 */
 	onAddTodo,
 	getInput,
 	showMessage
 }){
+	/**
+	 * TODO: querySelector durch dashboardSelectors.addTodoForm ersetzen.
+	 * Die Referenz auf das Formular ist bereits zentral definiert und
+	 * muss auch hier genutzt werden.
+	 * Beispiel:
+	 * // Import von Selektoren
+     * import {dashboardSelectors} from "./dom/selectors.js"
+	 * const form = dashboardSelectors.addTodoForm;
+	 */
+	 
+	/**
+	 * Formular aus dashboard.html auswaehlen
+	 */
 	const form = document.querySelector("#addTodoForm");
+	
+	/**
+	 * Todo-Titel einholen
+	 */
 	const input = getInput();
 	
+	/**
+	 * Lauscht auf Formular-Aktionen in dashboard.html
+	 */
 	form.addEventListener("submit", async (e) => {
 		e.preventDefault();
 		
+		/**
+		 * Titel des Todos verarbeiten
+		 */
 		const title = input.value.trim();
 		
 		if(!title){
@@ -16,6 +73,9 @@ export function registerDashboardEvents({
 			return;
 		}
 		
+		/**
+		 * Neues Todo eintragen
+		 */
 		const result = await onAddTodo(title);
 		
 		if(result?.success){

--- a/projekt/public/js/dashboard/index.js
+++ b/projekt/public/js/dashboard/index.js
@@ -21,18 +21,35 @@ import {removeTodoItem, updateTodoItem} from "./render/todoRenderer.js"
 
 import {registerDashboardEvents} from "./events/dashboardEvents.js"
 
+
+/**
+ * Initialisiert das Dashboard nach dem Laden des DOMs.
+ *
+ * Haupt-Einstiegspunkt der Anwendung.
+ * Laedt Benutzerinformationen und Todos,
+ * registriert Eventhandler und rendert die Oberflaeche.
+ *
+ * @remarks
+ * Diese Logik soll in eine zentrale 'initDashboard()'-Funktion ausgelagert werden,
+ * um Wiederverwendbarkeit, Testbarkeit und bessere Trennung der Verantwortlichkeiten
+ * zu ermoeglichen.
+ *
+ * @todo Auslagerung in init-Modul und Refaktorisierung der index.js.
+ */
 document.addEventListener("DOMContentLoaded", () => {
-	/*
-		Abrufen der User-ID, um die Ueberschrift zu erstellen => welcomeMessageH1
-		Diese Funktion in ein Modul auslagern, weil man so etwas noch an
-		anderer Stelle gebrauchen koennte.
-		
-		Und in Tablle users noch einen Namen einfuegen und die Regestrierung anpassen
-		Name soll eingegeben werden.
-	*/
-	//	async-Funktion innerhalb von anderer Funktion
+	/**
+	 * Ruft Benutzerinformationen ab und erzeugt eine Willkommensnachricht im Dashboard.
+	 *
+	 * @returns {void}
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	async function loadUserData(){
 		try{
+			/**
+			 * Anfrage an die API zum Abrufen der Benutzerinformationen.
+			 */
 			const response = await getUserInfo();
 			
 			if("error" in response){
@@ -40,6 +57,9 @@ document.addEventListener("DOMContentLoaded", () => {
 				return;
 			}else{
 				console.log("Userinfo: ", response);
+				/**
+				 * Erzeugen der Willkommensnachricht mit Vor- und Nachname.
+				 */
 				dashboardSelectors.welcomeMessageH1.textContent = `Welcome, ${response.first_name} ${response.surname}`;
 			}
 		}catch(err){
@@ -48,8 +68,19 @@ document.addEventListener("DOMContentLoaded", () => {
 		}
 	}
 	
+	/**
+	 * Ruft die Todos des aktuellen Benutzers ab und rendert sie im Dashboard.
+	 *
+	 * @returns {void}
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	async function loadUserTodos(){
 		try{
+			/**
+			 * Anfrage an die API zum Abrufen der Todos.
+			 */
 			const response = await getTodos();
 			
 			if("error" in response){
@@ -57,6 +88,9 @@ document.addEventListener("DOMContentLoaded", () => {
 				return;
 			}else{
 				console.log('Todos: ', response);
+				/**
+				 * Darstellung der Todos im UI mithilfe des zentralen Renderers.
+				 */
 				renderTodoList(response, {
 					onToggle: toggleUserTodoStatus,
 					onDelete: deleteUserTodo
@@ -67,20 +101,34 @@ document.addEventListener("DOMContentLoaded", () => {
 		}
 	}
 	
+	/**
+	 * Aktualisiert den Status eines Todos und rendert die Aenderung im DOM.
+	 *
+	 * @param {number} id - Die ID des zu aktualisierenden Todos.
+	 * @returns {void}
+	 *
+	 * @remarks
+	 * Da 'updateTodoItem()' intern 'createTodoListItem()' verwendet,
+	 * muessen sowohl 'onToggle' als auch 'onDelete' uebergeben werden,
+	 * um die Eventhandler korrekt zu setzen.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	async function toggleUserTodoStatus(id){
 		try{
+			/**
+			 * API-Aufruf zur Statusaenderung.
+			 */
 			const response = await toggleTodoStatus(id);
 			
 			if("error" in response){
 				console.error("Error: toggleUserTodoStatus() - ", response?.responseText);
 				return;
 			}else{
-				// Weil updateTodoItem() intern createTodoListItem() aufruft,
-				// und diese Funktion sowohl onToggle als auch onDelete braucht,
-				// um beide Eventhandler korrekt zu setzen, uebergibt man beides
-				// ...
-				// todoCheckbox.addEventListener("change", () => onToggle(todo.todo_id));
-				// deleteButton.addEventListener("click", () => onDelete(todo.todo_id));
+				/**
+				 * Status aktualisieren und neuen Status im DOM abbilden.
+				 */
 				updateTodoItem(response.completeTodo, {
 					onToggle: toggleUserTodoStatus,
 					onDelete: deleteUserTodo
@@ -92,16 +140,30 @@ document.addEventListener("DOMContentLoaded", () => {
 		}
 	}
 	
-	
-	//	addUserTodo - Anfang
+	/**
+	 * Fuegt ein neues Todo hinzu und rendert es im Dashboard.
+	 * Wird als Callback an 'registerDashboardEvents' uebergeben.
+	 *
+	 * @param {string} title - Titel des neuen Todos.
+	 * @returns {Promise<{success: boolean, message?: string} | void>}
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	async function addUserTodo(title){
 		try{
+			/**
+			 * API-Aufruf um neues Todos hinzuzufuegen.
+			 */
 			const response = await addTodo(title);
 			
 			if("error" in response){
 				console.error("Error: addUserTodo() - ", response?.responseText);
 				return;
 			}else{
+				/**
+				 * Neues Todo in die Liste einhaengen und im DOM rendern.
+				 */
 				appendTodoItem(response.completeTodo, {
 					onToggle: toggleUserTodoStatus,
 					onDelete: deleteUserTodo
@@ -120,22 +182,29 @@ document.addEventListener("DOMContentLoaded", () => {
 		showMessage: (msg) => dashboardSelectors.messageAddTodo.textContent = msg
 	});
 	
-	//	addUserTodo - Ende
-	
-	/*
-		WICHTIG
-		WENN NUR EIN EINZELNES TODO IN DER LISTE IST, KOMMT ES ZU EINEM FEHLER BEIM LOESCHEN
-		BZW WIRD DIE ANZEIGE NICHT AKTUALISIERT
-	*/
-	
+	/**
+	 * Loescht ein Todo
+	 *
+	 * @param {number} id - Die ID des zu loeschenden Todos.
+	 * @returns {void}
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	async function deleteUserTodo(id){
 		try{
+			/**
+			 * API-Aufruf um ein bestimmtes Todo zu loeschen.
+			 */
 			const response = await deleteTodo(id);
 			
 			if("error" in response){
 				console.error("Error: deleteUserTodo() - ", response?.responseText);
 				return;
 			}else{
+				/**
+				 * Todo loeschen.
+				 */
 				removeTodoItem(id);
 				console.log("Die neue Todo-Liste:", response);
 			}

--- a/projekt/public/js/shared/api/fetchWrapper.js
+++ b/projekt/public/js/shared/api/fetchWrapper.js
@@ -1,3 +1,9 @@
+	/**
+	 * @typedef {Object} ApiError
+	 * @property {boolean} error - Zeigt an, dass ein Fehler aufgetreten ist.
+	 * @property {string} responseText - Die Antwort des Servers als Text.
+	 */
+
 /**
  * Fuehrt eine HTTP-Anfrage an eine beliebige API aus.
  *
@@ -5,7 +11,7 @@
  * @param {string} [method='GET'] - Die HTTP-Methode (z.B. 'GET', 'POST').
  * @param {Object|null} [body=null] - Der Request-Body, wird als JSON gesendet.
  * @param {string|null} [token=null] - Bearer-Token zur Authentifizierung (optional).
- * @returns {Promise<Object>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ * @returns {Promise<Object|ApiError> } API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
  */
 export async function apiRequest(endpoint, method='GET', body=null, token=null){
 	/**
@@ -52,8 +58,10 @@ export async function apiRequest(endpoint, method='GET', body=null, token=null){
 	if(contentType.includes("application/json")){
 		const data = await response.json();
 		return data;
+	
 	/**
-	 * Fehlerfall, wenn Antworttyp nicht JSON
+	 * 
+	 * @returns {Promise<Object|}
 	 */
 	}else{
 		const text = await response.text();

--- a/projekt/public/js/shared/api/fetchWrapper.js
+++ b/projekt/public/js/shared/api/fetchWrapper.js
@@ -53,16 +53,13 @@ export async function apiRequest(endpoint, method='GET', body=null, token=null){
 	const contentType = response.headers.get('Content-Type') || "";
 	
 	/**
-	 * Erfolgsfall, wenn Antworttyp JSON
+	 * HINWEIS:
+     * Die Rückgabe erfolgreicher API-Antworten ist derzeit als {Object} typisiert.
+     * Passendes @typedef-Objekt erstellen und die @returns-Typen entsprechend konkretisieren.
 	 */
 	if(contentType.includes("application/json")){
 		const data = await response.json();
 		return data;
-	
-	/**
-	 * 
-	 * @returns {Promise<Object|}
-	 */
 	}else{
 		const text = await response.text();
 		return{

--- a/projekt/public/js/shared/api/fetchWrapper.js
+++ b/projekt/public/js/shared/api/fetchWrapper.js
@@ -11,7 +11,7 @@
  * @param {string} [method='GET'] - Die HTTP-Methode (z.B. 'GET', 'POST').
  * @param {Object|null} [body=null] - Der Request-Body, wird als JSON gesendet.
  * @param {string|null} [token=null] - Bearer-Token zur Authentifizierung (optional).
- * @returns {Promise<Object|ApiError> } API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
  */
 export async function apiRequest(endpoint, method='GET', body=null, token=null){
 	/**

--- a/projekt/public/js/shared/api/fetchWrapper.js
+++ b/projekt/public/js/shared/api/fetchWrapper.js
@@ -1,38 +1,61 @@
+/**
+ * Fuehrt eine HTTP-Anfrage an eine beliebige API aus.
+ *
+ * @param {string} endpoint - Die URL der API.
+ * @param {string} [method='GET'] - Die HTTP-Methode (z.B. 'GET', 'POST').
+ * @param {Object|null} [body=null] - Der Request-Body, wird als JSON gesendet.
+ * @param {string|null} [token=null] - Bearer-Token zur Authentifizierung (optional).
+ * @returns {Promise<Object>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function apiRequest(endpoint, method='GET', body=null, token=null){
-	// Das signalisiert dem Server: „Ich sende dir JSON-Daten“
-	// Header-Objekt initialisieren, standardmäßig mit JSON als Content-Type
+	/**
+	 * Der header enthaelt JSON-Daten.
+	 */
 	const headers = {
 		"Content-Type": "application/json"
 	};
-	// Optionaler Header hinzufügen, wenn token gesetzt ist
-	// Bearer ist das standardisierte Schema für den Authorization-Header
+	/**
+	 * Wenn Token gesetzt, wird der Header um diesen erweitert.
+	 */
 	if(token){
 		headers["Authorization"] = `Bearer ${token}`;
 	}
 	
-	// Optionen für fetch() vorbereiten (HTTP-Methode + Header)
+	/**
+	 * Vorbereitungsarbeiten fuer API-Abfrage per fetch()
+	 */
 	const options = {
 		method,
 		headers
 	};
 	
-	// Falls ein Body vorhanden ist, als JSON-String anhängen
+	/**
+	 * Einhaengen des Bodys, wenn vorhanden
+	 */
 	if(body){
 		options.body = JSON.stringify(body);
 	}
 	
-	// fetch()-Aufruf mit vorbereitetem Endpoint und Optionen
+	/**
+	 * Anfrage an Server senden und auf Antwort warten
+	 */
 	const response = await fetch(endpoint, options);
 	
-	// Content-Type prüfen, um zu entscheiden, ob wir JSON oder Text erwarten
+	/**
+	 * Pruefen des Typs der API-Antwort
+	 */
 	const contentType = response.headers.get('Content-Type') || "";
 	
+	/**
+	 * Erfolgsfall, wenn Antworttyp JSON
+	 */
 	if(contentType.includes("application/json")){
-		// Wenn JSON-Antwort -> als Objekt zurückgeben
 		const data = await response.json();
 		return data;
+	/**
+	 * Fehlerfall, wenn Antworttyp nicht JSON
+	 */
 	}else{
-		// Wenn kein JSON -> Text extrahieren und in Objekt verpackt zurückgeben
 		const text = await response.text();
 		return{
 			error: true,

--- a/projekt/public/js/shared/api/fetchWrapper.js
+++ b/projekt/public/js/shared/api/fetchWrapper.js
@@ -1,8 +1,8 @@
-	/**
-	 * @typedef {Object} ApiError
-	 * @property {boolean} error - Zeigt an, dass ein Fehler aufgetreten ist.
-	 * @property {string} responseText - Die Antwort des Servers als Text.
-	 */
+/**
+ * @typedef {Object} ApiError
+ * @property {boolean} error - Zeigt an, dass ein Fehler aufgetreten ist.
+ * @property {string} responseText - Die Antwort des Servers als Text.
+ */
 
 /**
  * Fuehrt eine HTTP-Anfrage an eine beliebige API aus.

--- a/projekt/public/js/shared/api/todo.js
+++ b/projekt/public/js/shared/api/todo.js
@@ -3,11 +3,22 @@ import {apiRequest} from "./fetchWrapper.js"
 // Importiert Hilfsfunktion zur Token-Ermittlung aus dem localStorage
 import {getToken} from "./../utils/token.js"
 
-// Ruft alle Todos des aktuellen Users vom Server ab
-// Erweitern um folgendes:
-// prüfen, ob response.xxx, also ob eine gueltige Antwort von der API
-// geliefert wird
+/**
+ * @typedef {Object} ApiError
+ * @property {boolean} error - Zeigt an, dass ein Fehler aufgetreten ist.
+ * @property {string} responseText - Die Antwort des Servers als Text.
+ */
+
+/**
+ * API-Abfrage der Benutzer-Todos
+ *
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function getTodos(){
+	/**
+	 * Ausstehende Erweiterung:
+	 * prüfen, ob response.xxx, also ob eine gueltige Antwort von der API geliefert wird
+	 */
 	const endpoint = "/api/get_user_todos.php";
 	const method = "GET";
 	const body = null;
@@ -16,11 +27,16 @@ export async function getTodos(){
 	return await apiRequest(endpoint, method, body, token);
 }
 
-// Erstellt ein neues Todo mit dem uebergebenen Titel
-// Erweitern um folgendes:
-// prüfen, ob response.xxx, also ob eine gueltige Antwort von der API
-// geliefert wird
+/**
+ * Einem Benutzer Todo hinzufuegen per API
+ *
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function addTodo(title){
+	/**
+	 * Ausstehende Erweiterung:
+	 * prüfen, ob response.xxx, also ob eine gueltige Antwort von der API geliefert wird
+	 */
 	const endpoint = "/api/addUserTodo.php";
 	const method = "POST";
 	const body = {title};
@@ -29,11 +45,16 @@ export async function addTodo(title){
 	return await apiRequest(endpoint, method, body, token);
 }
 
-// Ändert den Status eines bestimmten Todos
-// Erweitern um folgendes:
-// prüfen, ob response.xxx, also ob eine gueltige Antwort von der API
-// geliefert wird
+/**
+ * Todo-Status eines Nutzers aktualisieren
+ *
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function toggleTodoStatus(id){
+	/**
+	 * Ausstehende Erweiterung:
+	 * prüfen, ob response.xxx, also ob eine gueltige Antwort von der API geliefert wird
+	 */
 	const endpoint = "/api/toggleUserTodoStatus.php";
 	const method = "PATCH";
 	const body = {id};
@@ -46,7 +67,17 @@ export async function toggleTodoStatus(id){
 // Erweitern um folgendes:
 // prüfen, ob response.xxx, also ob eine gueltige Antwort von der API
 // geliefert wird
+
+/**
+ * Todo eines Nutzers loeschen
+ *
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function deleteTodo(id){
+	/**
+	 * Ausstehende Erweiterung:
+	 * prüfen, ob response.xxx, also ob eine gueltige Antwort von der API geliefert wird
+	 */
 	const endpoint = "/api/deleteUserTodo.php";
 	const method = "DELETE";
 	const body = {id};

--- a/projekt/public/js/shared/api/user.js
+++ b/projekt/public/js/shared/api/user.js
@@ -3,10 +3,23 @@ import {apiRequest} from "./fetchWrapper.js"
 // Importiert Hilfsfunktion zur Token-Ermittlung aus dem localStorage
 import {getToken} from "./../utils/token.js"
 
-// Holt Benutzerinformationen des aktuell eingeloggten Users vom Server
-// Erweitern um folgendes:
-// prüfen, ob response.first_name oder response.surname fehlen
+/**
+ * @typedef {Object} ApiError
+ * @property {boolean} error - Zeigt an, dass ein Fehler aufgetreten ist.
+ * @property {string} responseText - Die Antwort des Servers als Text.
+ */
+
+/**
+ * Abrufen der Benutzerinformationen
+ *
+ * @returns {Promise<Object|ApiError>} API-Antwort im JSON-Format oder ein Objekt mit Fehlertext
+ */
 export async function getUserInfo(){
+	/**
+	 * Ausstehende Erweiterung:
+	 * prüfen, ob response.first_name oder response.surname fehlen
+	 * JSDoc um @typedef-Obejkt: UserInfo erweitern
+	 */
 	const endpoint = "/api/user_info.php";
 	const method = "GET";
 	const body = null;

--- a/projekt/public/js/shared/dom/elements.js
+++ b/projekt/public/js/shared/dom/elements.js
@@ -1,4 +1,9 @@
-//	Erzeugt ein HTML-Element mit Textinhalt
+/**
+ * HTML-Element mit Textinhalt erzeugen
+ * @param {string} tagName - Zu erstellendes HTML-Tag.
+ * @param {string} text - Inhalt des HTML-Elements.
+ * @returns {HTMLElement} Das erzeugte DOM-Element.
+ */
 export function createTextElement(tagName, text){
 	const el = document.createElement(tagName);
 	el.textContent = text;

--- a/projekt/public/js/shared/utils/token.js
+++ b/projekt/public/js/shared/utils/token.js
@@ -1,3 +1,8 @@
+/**
+ * Ermittelt den lokal gesetzten JWT-Token
+ *
+ * @returns {string|null} JWT-Token der aktuellen Sitzung oder null, wenn keiner gespeichert ist.
+ */
 export function getToken(){
 	return localStorage.getItem("jwt_token");
 }


### PR DESCRIPTION
### Hintergrund

Dieser Pull Request bringt JSDoc-Kommentare in viele Teile des Frontends. So kann man den Code später leichter verstehen, nutzen und erweitern.

---

### Änderungen im Detail

- JSDoc für Funktionen
- Typ-Beschreibungen für Fehlerobjekte in fetchWrapper.js
- Kommentar für die getToken()-Funktion
- @typedef für Todos und Event-Handler hinzugefügt
- DOM-Selektoren in selectors.js dokumentiert
- Kommentare für HTML-Element-Erzeugung (createTodoListItem, createEmptyTodoMessage)
- Funktionen zur Darstellung der Todo-Liste in todoRenderer.js dokumentiert
- registerDashboardEvents in dashboardEvents.js kommentiert
- Die index.js (Startpunkt des Dashboards) mit JSDoc versehen und Hinweise für späteren Umbau ergänzt

---

### Ziel / Zweck des PRs

- Der Code soll besser verständlich werden
- Späterer Umbau soll einfacher möglich sein
- Wichtige Typen und Schnittstellen sind jetzt dokumentiert

---

### Testhinweise

- Keine neuen Funktionen, nur Kommentare
- Test: Dashboard normal starten und alle Funktionen (laden, hinzufügen, löschen, Status ändern) durchklicken

---

### Hinweise für Reviewer

- Manche Dateien fehlen noch , diese werden später dokumentiert, wenn sie umgebaut sind
- In index.js stehen schon Hinweise, wo später Funktionen ausgelagert werden sollen
- Manche Kommentare sind bewusst ausführlich, damit der Code für alle gut verständlich ist

---

### Folgeänderungen (optional)

- Zentrale Datei für alle @typedef-Beschreibungen anlegen (zur besseren Wiederverwendung)
- index.js schrittweise umbauen und Funktionen in eigene Module auslagern
- Restliche Module und Funktionen im Frontend mit JSDoc dokumentieren