### PR TITLE
Docs/add phpdoc frontend comments

### DIFF
--- a/projekt/public/api/addUserTodo.php
+++ b/projekt/public/api/addUserTodo.php
@@ -2,8 +2,22 @@
 	require_once '../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	$pdo = Database::getConnection();
 	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 * Potenzial zur Modularisierung reicht bis einschliesslich Zeile 39:
+	 * - Anfragevalidierung (Header und Body)
+	 * - Einheitliche Fehlerbehandlung
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'POST'){
 		//	Methode nicht erlaubt
 		http_response_code(405);
@@ -11,21 +25,40 @@
 		exit();
 	}
 	
-	//	JSON-Daten auslesen
+	/*
+	 * Liest die JSON-Daten aus der Anfrage und extrahiert den Todo-Titel.
+	 */
 	$input = json_decode(file_get_contents('php://input'), true);
 	$titleTodo = $input['title'];
 	
+	/*
+	 * Prueft, ob ein Todo-Titel uebergeben wurde.
+	 * Gibt bei fehlendem Titel einen Fehler zurueck.
+	 */
 	if(!$titleTodo){
 		http_response_code(400);
 		echo json_encode(['error' => 'Todo-Titel muss angegeben werden']);
 		exit();
 	}
 	
+	/**
+	 * Extrahiert den Bearer-Token aus dem Authorization-Header der HTTP-Anfrage.
+	 * Unterstuezt Standard-Header sowie apache_request_headers() als Fallback.
+	 *
+	 * @return string|null Der Bearer-Token oder null wenn keiner gefunden wurde.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	function getBearerToken(): ?string{
-		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		/*
+		 * Header direkt aus $_SERVER.
+		 */
 		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
 		
-		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		/*
+		 * Fallback fuer Apache.
+		 */
 		if(empty($authHeader) && function_exists('apache_request_headers')){
 			$headers = apache_request_headers();
 			if(isset($headers['Authorization'])){
@@ -33,30 +66,62 @@
 			}
 		}
 		
-		//	3.	Pruefe auf Bearer
+		/*
+		 * Extrahiere Token, wenn Bearer vorhanden
+		 */
 		if(str_starts_with($authHeader, 'Bearer ')){
 			return trim(substr($authHeader, 7));
 		}
 		
+		/*
+		 * Kein gueltiger Token
+		 */
 		return null;
 	}
-	
+
 	$token = getBearerToken();
 	
+	/*
+	 * Prueft, ob ein gueltiger Token vorhanden ist.
+	 * Gibt bei fehlendem oder ungueltigem Token einen Fehler zurueck.
+	 *
+	 * @todo
+     * Diese Token-Pruefung sollte ausgelagert werden.
+	 * Sie wird an mehreren Stellen im Projekt wiederverwendet.
+	 * Ziel: zentrale Methode, die Token validiert und bei Fehlern eine
+	 * konsistente Antwort erzeugt.
+	 */
 	if(!$token){
-		//	Bad Request
 		http_response_code(400);
 		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
 		exit();
 	}
 	
-	//	JWT ueberprufen
-	//	Neue Insanz der Klasse: JwtHandler
-	//	Konstruktoraufruf
+	/**
+	 * Prueft, ob die Token-Signatur gueltig ist und liest die Benutzer-ID aus.
+	 * 
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 *
+	 * @remarks
+	 * Nutzt die JwtHandler-Klasse:
+	 * 1. validiert den Token,
+	 * 2. extrahiert die user_id
+	 */
 	$jwt = new \Core\JwtHandler();
 	$userData = $jwt->validateToken($token);
 	$userId = $jwt->getUserIdFromToken($token);
 	
+	/*
+	 * Prueft, ob die Benutzerinformationen vorhanden sind.
+	 * Gibt bei fehlender Autorisierung einen Fehler zurueck.
+	 *
+	 * @todo
+     * Die Pruefung auf gueltige Benutzerinformationen inklusive Fehlerbehandlung
+	 * kann ausgelagert werden, diese wird auch an anderen Stellen benoetigt.
+	 * Ziel: zentrale Methode zur Autorisierungspruefung, die bei ungueltigem Benutzer
+	 * einheitlich mit Fehlercode und Nachricht reagiert.
+	 */
 	if($userData === null){
 		http_response_code(401);
 		echo json_encode(['error' => 'Token nicht gueltig oder abgelaufen']);
@@ -65,14 +130,49 @@
 	
 	$todoId = addTodo($pdo, $userId, $titleTodo);
 	
+	/**
+	 * Antwortstruktur fuer Erfgolgsmeldung
+	 *
+	 * Erfolgsfall:
+	 * @return array{
+	 *   success: bool,
+	 *   completeTodo: array{
+	 *	   todo_id: int,
+	 *     todo_title: string,
+	 *     todo_status: int,
+	 *     todo_iat: string
+	 *  }
+	 * }
+	 *
+	 * Fehlerfall:
+	 * @return array{
+	 *   success: false,
+	 *   message: string
+	 * }
+	 *
+	 * @see addTodo
+	 *
+	 * @todo
+     * Diese JSON-Antwort sollte in eine Hilfsfunktion ausgelagert werden,
+	 * um Wiederverwendung und klarere Struktur zu ermoeglichen.
+	 * Langfristig waere auch eine eine vereinheitlichte JSON-Antwortstruktur fuer alle
+	 * API-Endpunkte sinnvoll, die Payloads konsistent behandeln.
+	 */
+	
+	/*
+	 * Versende das erfolgreich erstellte Todo an das Frontend.
+	 */
 	if($todoId !== null){
-		//	Neues Todo aus DB lesen
-		//	Mit allen dazugehoerenden Spalten
+		/*
+		 * Todo mit allen Informationen aus der DB auslesen.
+		 */
 		$stmt = $pdo->prepare("select * from todos where id = ?");
 		$stmt->execute([$todoId]);
 		$newTodo = $stmt->fetch(PDO::FETCH_ASSOC);
 		
-		//	Feldnamenanpassen fuer Rendering
+		/*
+		 * Bereite das Todo fuer die Antwort an das Frontend vor.
+		 */
 		$newTodo = [
 			'todo_id' => $newTodo['id'],
 			'todo_title' => $newTodo['title'],
@@ -80,12 +180,15 @@
 			'todo_iat' => $newTodo['created_at']
 		];
 		
-		//	Vollstaendiges Todo als JSON senden
 		echo json_encode([
 			'success' => true,
 			'completeTodo' => $newTodo
 		]);
 	}else{
+		/*
+		 * Todo wurde nicht erzeugt.
+		 * Sende Fehlermeldung an das Frontend.
+		 */
 		echo json_encode([
 			'success' => false,
 			'message' => 'Fehler beim Hinzufuegen des Todos'

--- a/projekt/public/api/deleteUserTodo.php
+++ b/projekt/public/api/deleteUserTodo.php
@@ -1,16 +1,23 @@
 <?php
-
-	/*
-		WICHTIG
-		WENN NUR EIN EINZELNES TODO IN DER LISTE IST, KOMMT ES ZU EINEM FEHLER BEIM LOESCHEN
-		BZW WIRD DIE ANZEIGE NICHT AKTUALISIERT
-	*/
-
 	require_once __DIR__ . '/../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	$pdo = Database::getConnection();
 	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 * Potenzial zur Modularisierung reicht bis einschliesslich Zeile 36:
+	 * - Anfragevalidierung (Header und Body)
+	 * - Einheitliche Fehlerbehandlung
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'DELETE'){
 		//	Methode nicht erlaubt
 		http_response_code(405);
@@ -18,21 +25,40 @@
 		exit();
 	}
 	
-	//	JSON-Daten auslesen
+	/*
+	 * Liest die JSON-Daten aus der Anfrage und extrahiert die Todo-ID.
+	 */
 	$input = json_decode(file_get_contents('php://input'), true);
 	$todoId = $input['id'];
 	
+	/*
+	 * Prueft, ob eine Todo-ID uebergeben wurde.
+	 * Gibt bei fehlender ID einen Fehler zurueck.
+	 */
 	if(!$todoId){
 		http_response_code(400);
 		echo json_encode(['error' => 'Todo-ID muss angegeben werden']);
 		exit();
 	}
 	
+	/**
+	 * Extrahiert den Bearer-Token aus dem Authorization-Header der HTTP-Anfrage.
+	 * Unterstuezt Standard-Header sowie apache_request_headers() als Fallback.
+	 *
+	 * @return string|null Der Bearer-Token oder null wenn keiner gefunden wurde.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	function getBearerToken(): ?string{
-		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		/*
+		 * Header direkt aus $_SERVER.
+		 */
 		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
 		
-		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		/*
+		 * Fallback fuer Apache.
+		 */
 		if(empty($authHeader) && function_exists('apache_request_headers')){
 			$headers = apache_request_headers();
 			if(isset($headers['Authorization'])){
@@ -40,16 +66,31 @@
 			}
 		}
 		
-		//	3.	Pruefe auf Bearer
+		/*
+		 * Extrahiere Token, wenn Bearer vorhanden
+		 */
 		if(str_starts_with($authHeader, 'Bearer ')){
 			return trim(substr($authHeader, 7));
 		}
 		
+		/*
+		 * Kein gueltiger Token
+		 */
 		return null;
 	}
 	
 	$token = getBearerToken();
 	
+	/*
+	 * Prueft, ob ein gueltiger Token vorhanden ist.
+	 * Gibt bei fehlendem oder ungueltigem Token einen Fehler zurueck.
+	 *
+	 * @todo
+     * Diese Token-Pruefung sollte ausgelagert werden.
+	 * Sie wird an mehreren Stellen im Projekt wiederverwendet.
+	 * Ziel: zentrale Methode, die Token validiert und bei Fehlern eine
+	 * konsistente Antwort erzeugt.
+	 */
 	if(!$token){
 		//	Bad Request
 		http_response_code(400);
@@ -57,13 +98,39 @@
 		exit();
 	}
 	
-	//	JWT ueberprufen
-	//	Neue Insanz der Klasse: JwtHandler
-	//	Konstruktoraufruf
+    /**
+	 * Prueft, ob die Token-Signatur gueltig ist und liest die Benutzer-ID aus.
+	 * 
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 *
+	 * @remarks
+	 * Nutzt die JwtHandler-Klasse:
+	 * 1. validiert den Token,
+	 * 2. extrahiert die user_id
+	 */
 	$jwt = new \Core\JwtHandler();
 	$userData = $jwt->validateToken($token);
 	$userId = $jwt->getUserIdFromToken($token);
 	
+	/*
+	 * Prueft, ob die Benutzerinformationen vorhanden sind.
+	 * Gibt bei fehlender Autorisierung einen Fehler zurueck.
+	 *
+	 * @todo
+     * Die Pruefung auf gueltige Benutzerinformationen inklusive Fehlerbehandlung
+	 * kann ausgelagert werden, diese wird auch an anderen Stellen benoetigt.
+	 * Ziel: zentrale Methode zur Autorisierungspruefung, die bei ungueltigem Benutzer
+	 * einheitlich mit Fehlercode und Nachricht reagiert.
+	 *
+	 * @todo
+	 * Die Logik der Fehlerbehandlung ist falsch.
+	 * Unbedingt anpassen.
+	 *
+	 * @remarks
+	 * Wenn userData null ist, kann nicht darauf zugegriffen werden.
+	 * Dies fuehrt zu unvorhersehbaren Problemen im Programmablauf.
+	 */
 	if($userData === null){
 		http_response_code(401);
 		echo json_encode(['error' => $userData['message']]);
@@ -72,10 +139,40 @@
 	
 	$deleteSuccess = deleteTodo($pdo, $userId, $todoId);
 	
+	/**
+	 * Antwortstruktur fuer Backend-Meldung
+	 *
+	 * Erfolgsfall:
+	 * @return array{
+	 *   success: bool
+	 * }
+	 *
+	 * Fehlerfall:
+	 * @return array{
+	 *   success: false,
+	 *   message: string
+	 * }
+	 *
+	 * @see deleteTodo
+	 *
+	 * @todo
+     * Diese JSON-Antwort sollte in eine Hilfsfunktion ausgelagert werden,
+	 * um Wiederverwendung und klarere Struktur zu ermoeglichen.
+	 * Langfristig waere auch eine eine vereinheitlichte JSON-Antwortstruktur fuer alle
+	 * API-Endpunkte sinnvoll, die Payloads konsistent behandeln.
+	 */
+	
+	/*
+	 * Versende an Frontend, dass Todo erfolgreich geloescht wurde.
+	 */
 	if($deleteSuccess){
-		echo json_encode(['success' => true]);
 		
+		echo json_encode(['success' => true]);
 	}else{
+		/*
+		 * Todo wurde nicht geloescht.
+		 * Sende Fehlermeldung an das Frontend.
+		 */
 		http_response_code(404);
 		echo json_encode([
 			'success' => false,

--- a/projekt/public/api/get_user_todos.php
+++ b/projekt/public/api/get_user_todos.php
@@ -2,20 +2,43 @@
 	require_once __DIR__ . '/../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	$pdo = Database::getConnection();
 	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'GET'){
-		//	Methode nicht erlaubt
 		http_response_code(405);
 		echo json_encode(['error' => 'Nur Get-Anfragen erlaubt']);
 		exit();
 	}
 	
+	/**
+	 * Extrahiert den Bearer-Token aus dem Authorization-Header der HTTP-Anfrage.
+	 * Unterstuezt Standard-Header sowie apache_request_headers() als Fallback.
+	 *
+	 * @return string|null Der Bearer-Token oder null wenn keiner gefunden wurde.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	function getBearerToken(): ?string{
-		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		/*
+		 * Header direkt aus $_SERVER.
+		 */
 		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
 		
-		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		/*
+		 * Fallback fuer Apache.
+		 */
 		if(empty($authHeader) && function_exists('apache_request_headers')){
 			$headers = apache_request_headers();
 			if(isset($headers['Authorization'])){
@@ -23,47 +46,120 @@
 			}
 		}
 		
-		//	3.	Pruefe auf Bearer
+		/*
+		 * Extrahiere Token, wenn Bearer vorhanden
+		 */
 		if(str_starts_with($authHeader, 'Bearer ')){
 			return trim(substr($authHeader, 7));
 		}
 		
+		/*
+		 * Kein gueltiger Token
+		 */
 		return null;
 	}
 	
 	$token = getBearerToken();
 	
+	/*
+	 * Prueft, ob ein gueltiger Token vorhanden ist.
+	 * Gibt bei fehlendem oder ungueltigem Token einen Fehler zurueck.
+	 *
+	 * @todo
+     * Diese Token-Pruefung sollte ausgelagert werden.
+	 * Sie wird an mehreren Stellen im Projekt wiederverwendet.
+	 * Ziel: zentrale Methode, die Token validiert und bei Fehlern eine
+	 * konsistente Antwort erzeugt.
+	 */
 	if(!$token){
-		//	Bad Request
 		http_response_code(400);
 		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
 		exit();
 	}
 	
-	//	JWT ueberprufen
-	//	Neue Insanz der Klasse: JwtHandler
-	//	Konstruktoraufruf
+    /**
+	 * Prueft, ob die Token-Signatur gueltig ist und liest die Benutzer-ID aus.
+	 * 
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 *
+	 * @remarks
+	 * Nutzt die JwtHandler-Klasse:
+	 * 1. validiert den Token,
+	 * 2. extrahiert die user_id
+	 */
 	$jwt = new \Core\JwtHandler();
 	$userData = $jwt->validateToken($token);
 	$userId = $jwt->getUserIdFromToken($token);
 	
+	/*
+	 * Prueft, ob die Benutzerinformationen vorhanden sind.
+	 * Gibt bei fehlender Autorisierung einen Fehler zurueck.
+	 *
+	 * @todo
+     * Die Pruefung auf gueltige Benutzerinformationen inklusive Fehlerbehandlung
+	 * kann ausgelagert werden, diese wird auch an anderen Stellen benoetigt.
+	 * Ziel: zentrale Methode zur Autorisierungspruefung, die bei ungueltigem Benutzer
+	 * einheitlich mit Fehlercode und Nachricht reagiert.
+	 *
+	 * @todo
+	 * Die Logik der Fehlerbehandlung ist falsch.
+	 * Unbedingt anpassen.
+	 *
+	 * @remarks
+	 * Wenn userData null ist, kann nicht darauf zugegriffen werden.
+	 * Dies fuehrt zu unvorhersehbaren Problemen im Programmablauf.
+	 */
 	if($userData === null){
 		http_response_code(401);
 		echo json_encode(['error' => $userData['message']]);
 		exit();
 	}
 	
-	//	Nutzerdaten aus DB holen
 	$userTodos = getTodosByUser($pdo, $userId);
 	
+	/**
+	 * Antwortstruktur fuer Backend-Meldung
+	 *
+	 * Erfolgsfall:
+	 * @return array<int, array{
+	 *	   todo_id: int,
+	 *     todo_title: string,
+	 *     todo_status: int,
+	 *     todo_iat: string
+	 *  }>
+	 *
+	 * Fehlerfall:
+	 * @return array{error: string}
+	 *
+	 * @see getTodosByUser
+	 *
+	 * @todo
+     * Diese JSON-Antwort sollte in eine Hilfsfunktion ausgelagert werden,
+	 * um Wiederverwendung und klarere Struktur zu ermoeglichen.
+	 * Langfristig waere auch eine eine vereinheitlichte JSON-Antwortstruktur fuer alle
+	 * API-Endpunkte sinnvoll, die Payloads konsistent behandeln.
+	 */
+	
+	/*
+	 * Fehlerantwort, wenn Nutzer keine Todos hat.
+	 */
 	if(!is_array($userTodos)){
 		http_response_code(500);
-		echo json_encode(['error' => 'Benutzer-Todos nicht gefunden']);
+		echo json_encode([
+			'error' => 'Benutzer-Todos nicht gefunden'
+		]);
 		exit();
 	}
 	
+	/*
+	 * Datenstruktur zum buendeln der Todos.
+	 */
 	$formattedTodos = [];
 	
+	/*
+	 * Alles Todos werden gebuendelt.
+	 */
 	foreach($userTodos as $todo){
 		$formattedTodos[] = [
 			'todo_id' => $todo['id'],
@@ -73,5 +169,8 @@
 		];
 	}
 	
+	/*
+	 * Wenn Nutzer Todos hat, sende diese an das Frontend.
+	 */
 	echo json_encode($formattedTodos);
 ?>

--- a/projekt/public/api/login.php
+++ b/projekt/public/api/login.php
@@ -1,8 +1,19 @@
 <?php
 	require_once __DIR__ . '/../../bootstrap/init.php';
 
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	header('Content-Type: application/json');
 	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'POST'){
 		//	Methode nicht erlaubt
 		http_response_code(405);
@@ -10,11 +21,19 @@
 		exit();
 	}
 	
-	//	JSON-Daten auslesen
+	/*
+	 * Liest die JSON-Daten aus der Anfrage und extrahiert:
+	 * - E-Mail,
+	 * - Passwort
+	 */
 	$input = json_decode(file_get_contents('php://input'), true);
 	$email = $input['email'] ?? '';
 	$password = $input['password'] ?? '';
 	
+	/*
+	 * Prueft, ob E-Mail und Passwort uebergeben wurden.
+	 * Gibt bei fehlender E-Mail oder Passwort einen Fehler zurueck.
+	 */
 	if(!$email || !$password){
 		//	Bad Request
 		http_response_code(400);
@@ -22,10 +41,19 @@
 		exit();
 	}
 	
-	//	Login durchfuehren
 	$loginMessage = processLoginForm();
+	
+	/*
+	 * Versendet entweder ein Token mit Nutzerdaten oder eine Fehlermeldung.
+	 *
+	 * @todo
+	 * Error-Code anpassen
+	 *
+	 * @remark
+	 * 400 Bad Request ist fuer fehlerhafte Struktur der Anfrage.
+	 * Stattdessen 401 (Login fehlgeschlagen) als Error-Code verwenden.
+	 */
 	if(isset($loginMessage['error'])){
-		//	oder 401 je nach Fehlerart
 		http_response_code(400);
 	}else{
 		http_response_code(200);

--- a/projekt/public/api/register.php
+++ b/projekt/public/api/register.php
@@ -1,9 +1,16 @@
 <?php
-	//	ANPASSEN: REGISTER-FUNKTIONALITAET
-	//	NAME UND VORNAME EINFUEGEN
+	/**
+	 * @httpcode 500 Internal Server Error
+	 * @httpcode 405 Method Not Allowed
+	 * @httpcode 400 Bad Request
+	 */
+
 	require_once __DIR__ . '/../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	try{
 		$pdo = Database::getConnection();
 	}catch(\RuntimeException $e){
@@ -13,71 +20,107 @@
 		echo json_encode(['error' => $e->getMessage()]);
 		exit();
 	}
-	
-	//	Das heisst, wir pruefen hier, ob unsere Anfrage per Post-
-	//	Methode erfolgt, wenn ja, dann holen wir die Daten aus der Anfrage,
-	//	die wir zuvor per JS-Code bzw fetch versendet haben?
+
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'POST'){
-		//	Methode nicht erlaubt
-		//	Was ist hier mit Methode konkret gemeint und was bedeutet
-		//	der http response code 405?
-		//	405 = Method not allowed
 		http_response_code(405);
 		echo json_encode(['error' => 'Nur Post-Anfragen erlaubt']);
 		exit();
 	}
 	
-	//	JSON-Daten auslesen
-	//	Bitte erlaetere mir die Funktion:
-	//	file_get_contents() - Parameter und Rueckgabewert
+	/*
+	 * Liest die JSON-Daten aus der Anfrage und extrahiert:
+	 * - E-Mail,
+	 * - Passwort,
+	 * - Vorname,
+	 * - Nachname
+	 */
 	$input = json_decode(file_get_contents('php://input'), true);
 	$email = $input['email'] ?? '';
 	$password = $input['password'] ?? '';
 	$firstName = $input['firstName'] ?? '';
 	$surname = $input['surname'] ?? '';
 	
+	/*
+	 * Prueft, ob:
+	 * - E-Mail,
+	 * - Passwort,
+	 * - Vorname,
+	 * - Nachname
+	 * uebergeben wurde.
+	 * Gibt bei fehlendem Titel einen Fehler zurueck.
+	 */
 	if(!$email || !$password || !$firstName || !$surname){
-		//	Bad Request
-		//	Was ist hier mit Methode konkret gemeint und was bedeutet
-		//	der http response code 405?
-		//	400 = Bad Request
 		http_response_code(400);
 		echo json_encode(['error' => 'E-Mail, Passwort, Vor- und Nachname sind erforderlich']);
 		exit();
 	}
 	
-	//	Prüfen, ob Email regestriert ist (inkl. Validierung)
 	$emailError = isEmailRegistered($pdo, $email);
+	
+	/*
+	 * Prueft, ob die empfangene E-mail gueltig ist.
+	 */
 	if($emailError !== null){
-		//	Falls E-Mail ungültig oder bereits registriert
 		http_response_code(400);
 		echo json_encode(['error' => $emailError]);
 		exit();
 	}
 	
+	/*
+	 * Fuehrt die Fehlerbehandlung im Kontext der Datenbank aus.
+	 */
 	try{
-		//	Nutzer erstellen
 		$result = createUser($pdo, $email, $password, $surname, $firstName);
+		/**
+		 * Antwortstruktur fuer Fehlermeldung
+		 *
+		 * @return array{
+		 *    error: string 
+		 * }
+		 */
+		 
+		/**
+		 * @todo
+		 * Die Fehlerbehandlung muss angepasst werden.
+		 * Wenn das result-Array nicht gesetzt ist, kann darauf auch nicht
+		 * zugegriffen werden. Genau dies wird aber gemacht.
+		 */
+		 
+		/*
+		 * Sende Fehlermeldung, wenn Nutzer nicht erstellt werden konnte.
+		 */
 		if(isset($result['error'])){
-			//	Falls beim Erstellen des Nutzers ein Fehler auftritt
 			http_response_code(400);
 			echo json_encode(['error' => $result['error']]);
 			exit();
 		}
-		//	Wenn die Regestrierung erfolgreich verlauft, dann wir eine
-		//	Erfolgsmeldung zurueck gegebn.
-		//	register.php ist dafür verantwortlich, das endgültige JSON auszugeben.
-		//	Deshalb nutzt du dort echo json_encode(...) – denn diese Datei "spricht
-		//	mit der Außenwelt" (z. B. JS/Browser).
+		
+		/**
+		 * Antwortstruktur fuer Erfgolgsmeldung
+		 *
+		 * @return array{
+		 *    message: string 
+		 * }
+		 *
+		 * @remarks
+		 * Hier muessen die Daten als JSON versendet werden, weil eine direkte
+		 * Kommunikation zwischen Front- und Backend besteht.
+		 * Siehe: Grundstruktur-API-Architektur-Rueckgabeprinzipien.txt (in Aufzeichnungen)
+		 */
+		
+		/*
+		 * Sende Erfolgsmeldung, wenn Nutzer erstellt werden konnte.
+		 */
 		echo json_encode(['message' => 'Die Regestrierung war erfolgreich.']);
-	
 		}catch(\PDOException $e){
-			//	Fehlerbehandlung, falls ein Fehler bei der DB-Abfrage oder beim
-			//	Insert auftritt
-			//	Hier muss also auch ein http_response_code stehen
-			//	Und der eigentliche Fehler wird per JSON an die Aufrufende JS-Datei
-			//	zurueckgegeben. Zuletzt wird nur exit() aufgerufen
-			//	Ist das korrekt?
 			http_response_code(500);
 			echo json_encode(['error' => 'Fehler bei der Regestrierung: '.$e->getMessage()]);
 			exit();

--- a/projekt/public/api/toggleUserTodoStatus.php
+++ b/projekt/public/api/toggleUserTodoStatus.php
@@ -1,31 +1,74 @@
 <?php
+	/**
+	 * @httpcode 400 Bad Request
+	 * @httpcode 401 Unauthorized
+	 * @httpcode 405 Method Not Allowed
+	 */
+
 	require_once __DIR__ . '/../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	$pdo = Database::getConnection();
 	
+	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 * Potenzial zur Modularisierung reicht bis einschliesslich Zeile 43:
+	 * - Anfragevalidierung (Header und Body)
+	 * - Einheitliche Fehlerbehandlung
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'PATCH'){
-		//	Methode nicht erlaubt
 		http_response_code(405);
-		echo json_encode(['error' => 'Nur PATCH-Anfragen erlaubt']);
+		echo json_encode([
+			'error' => 'Nur PATCH-Anfragen erlaubt'
+		]);
 		exit();
 	}
 	
-	//	JSON-Daten auslesen
+	/*
+	 * Liest die JSON-Daten aus der Anfrage und extrahiert die Todo-ID.
+	 */
 	$input = json_decode(file_get_contents('php://input'), true);
 	$todoId = $input['id'] ?? '';
 	
+	/*
+	 * Prueft, ob die Todo-ID uebergeben wurde.
+	 * Gibt bei fehlender ID einen Fehler zurueck.
+	 */
 	if(!$todoId){
 		http_response_code(400);
-		echo json_encode(['error' => 'Todo-ID erforderlich']);
+		echo json_encode([
+			'error' => 'Todo-ID erforderlich'
+		]);
 		exit();
 	}
 	
+	/**
+	 * Extrahiert den Bearer-Token aus dem Authorization-Header der HTTP-Anfrage.
+	 * Unterstuezt Standard-Header sowie apache_request_headers() als Fallback.
+	 *
+	 * @return string|null Der Bearer-Token oder null wenn keiner gefunden wurde.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	function getBearerToken(): ?string{
-		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
+		/*
+		 * Header direkt aus $_SERVER.
+		 */
 		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
 		
-		//	2.	Wenn leer, nutze apache_request_headers (nur bei Apache verfuegbar)
+		/*
+		 * Fallback fuer Apache.
+		 */
 		if(empty($authHeader) && function_exists('apache_request_headers')){
 			$headers = apache_request_headers();
 			if(isset($headers['Authorization'])){
@@ -33,46 +76,115 @@
 			}
 		}
 		
-		//	3.	Pruefe auf Bearer
+		/*
+		 * Extrahiere Token, wenn Bearer vorhanden
+		 */
 		if(str_starts_with($authHeader, 'Bearer ')){
 			return trim(substr($authHeader, 7));
 		}
 		
+		/*
+		 * Kein gueltiger Token
+		 */
 		return null;
 	}
 	
 	$token = getBearerToken();
 	
+	/*
+	 * Prueft, ob ein gueltiger Token vorhanden ist.
+	 * Gibt bei fehlendem oder ungueltigem Token einen Fehler zurueck.
+	 *
+	 * @todo
+     * Diese Token-Pruefung sollte ausgelagert werden.
+	 * Sie wird an mehreren Stellen im Projekt wiederverwendet.
+	 * Ziel: zentrale Methode, die Token validiert und bei Fehlern eine
+	 * konsistente Antwort erzeugt.
+	 *
+	 * @todo Error-Code anpassen.
+	 *
+	 * @remarks
+	 * Statt dem aktuell genuzten Error-Code: 400, einen zutreffenderen finden.
+	 * Vorschlag: 401.
+	 */
 	if(!$token){
-		//	Bad Request
 		http_response_code(400);
-		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		echo json_encode([
+			'error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token'
+		]);
 		exit();
 	}
 	
-	//	JWT ueberprufen
-	//	Neue Insanz der Klasse: JwtHandler
-	//	Konstruktoraufruf
+	/**
+	 * Prueft, ob die Token-Signatur gueltig ist und liest die Benutzer-ID aus.
+	 * 
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 *
+	 * @remarks
+	 * Nutzt die JwtHandler-Klasse:
+	 * 1. validiert den Token,
+	 * 2. extrahiert die user_id
+	 */
 	$jwt = new \Core\JwtHandler();
 	$userData = $jwt->validateToken($token);
 	$userId = $jwt->getUserIdFromToken($token);
 	
+	/**
+	 * Prueft, ob die Benutzerinformationen vorhanden sind.
+	 * Gibt bei fehlender Autorisierung einen Fehler zurueck.
+	 *
+	 * @todo
+     * Die Pruefung auf gueltige Benutzerinformationen inklusive Fehlerbehandlung
+	 * kann ausgelagert werden, diese wird auch an anderen Stellen benoetigt.
+	 * Ziel: zentrale Methode zur Autorisierungspruefung, die bei ungueltigem Benutzer
+	 * einheitlich mit Fehlercode und Nachricht reagiert.
+	 */
 	if($userData === null){
 		http_response_code(401);
-		echo json_encode(['error' => 'Token nicht gueltig oder abgelaufen']);
+		echo json_encode([
+			'error' => 'Token nicht gueltig oder abgelaufen'
+		]);
 		exit();
 	}
 	
-	//	Toggle-Funktion ruft Status zurueck
 	$todoStatus = toggleTodo($pdo, $userId, $todoId);
 	
+	/**
+	 * Antwortstruktur fuer Backend-Meldung.
+	 *
+	 * Erfolgsfall:
+	 * @return array{
+	 *   success: bool,
+	 *   completeTodo: array{
+	 *     todo_id: int,
+	 *     todo_title: string,
+	 *     todo_status: int,
+	 *     todo_iat: string
+	 *  }
+	 * }
+	 *
+	 * Fehlerfall:
+	 * @return array{
+	 *   error: string
+	 * }
+	 */
+	 
+	/*
+	 * Erfolgreiche Statusanpassung an das Frontend senden.
+	 */
 	if($todoStatus === 1 || $todoStatus === 0){
 		// Aktualisiertes vollstaendiges Todo
+		/*
+		 * Rufe das gesamte, aktualisierte Todo ab.
+		 */
 		$stmt = $pdo->prepare("select * from todos where id = ?");
 		$stmt->execute([$todoId]);
 		$todoStatus = $stmt->fetch(PDO::FETCH_ASSOC);
 		
-		// Feldnamenanpassen fuer Rendering
+		/*
+		 * Todo-Struktur aufbereiten, damit diese im Frontend korrekt verarbeitet werden kann.
+		 */
 		$todoStatus = [
 			'todo_id' => $todoStatus['id'],
 			'todo_title' => $todoStatus['title'],
@@ -80,15 +192,23 @@
 			'todo_iat' => $todoStatus['created_at'],
 		];
 		
-		// Vollstaendiges Todo senden
+		/*
+		 * Sende das aktualisierte Todo.
+		 *
+		 * @todo Tippfehler korrigieren: succes -> success
+		 */
 		echo json_encode([
 			'succes' => true,
 			'completeTodo' => $todoStatus
 		]);
+	/*
+	 * Sende Fehlermeldung.
+	 */
 	}else{
 		http_response_code(401);
-		echo json_encode(['error' => 'Status wurde nicht geaendert']);
+		echo json_encode([
+			'error' => 'Status wurde nicht geaendert'
+		]);
 		exit();
 	}
-	
 ?>

--- a/projekt/public/api/user_info.php
+++ b/projekt/public/api/user_info.php
@@ -2,15 +2,37 @@
 	require_once __DIR__ . '/../../bootstrap/init.php';
 	header('Content-Type: application/json');
 	
+	/*
+	 * Holt eine bestehende oder erstellt eine neue PDO-Datenbankverbindung ueber die Database-Klasse.
+	 */
 	$pdo = Database::getConnection();
 	
+	/**
+	 * Prueft, ob die korrekte Anfrage-Methode verwendet wurde.
+	 * Beendet die Anfrage bei falscher Methode mit einem Fehlercode.
+	 *
+	 * @todo
+     * Auslagern in eine generische Hilfsfunktion zur Wiederverwendung in anderen Endpunkten.
+	 * Parameter sollten sein: erwartete HTTP-Methode, Fehlernachricht, Fehlercode.
+	 */
 	if($_SERVER['REQUEST_METHOD'] !== 'GET'){
 		//	Methode nicht erlaubt
 		http_response_code(405);
-		echo json_encode(['error' => 'Nur Get-Anfragen erlaubt']);
+		echo json_encode([
+			'error' => 'Nur Get-Anfragen erlaubt'
+		]);
 		exit();
 	}
 	
+	/**
+	 * Extrahiert den Bearer-Token aus dem Authorization-Header der HTTP-Anfrage.
+	 * Unterstuezt Standard-Header sowie apache_request_headers() als Fallback.
+	 *
+	 * @return string|null Der Bearer-Token oder null wenn keiner gefunden wurde.
+	 *
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 */
 	function getBearerToken(): ?string{
 		//	1. Versuche zuerst den Header aus $_SERVER (Standardfall)
 		$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
@@ -33,39 +55,110 @@
 	
 	$token = getBearerToken();
 	
+	/*
+	 * Prueft, ob ein gueltiger Token vorhanden ist.
+	 * Gibt bei fehlendem oder ungueltigem Token einen Fehler zurueck.
+	 *
+	 * @todo
+     * Diese Token-Pruefung sollte ausgelagert werden.
+	 * Sie wird an mehreren Stellen im Projekt wiederverwendet.
+	 * Ziel: zentrale Methode, die Token validiert und bei Fehlern eine
+	 * konsistente Antwort erzeugt.
+	 *
+	 * @todo Error-Code anpassen.
+	 *
+	 * @remarks
+	 * Statt dem aktuell genuzten Error-Code: 400, einen zutreffenderen finden.
+	 * Vorschlag: 401.
+	 */
 	if(!$token){
-		//	Bad Request
 		http_response_code(400);
-		echo json_encode(['error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token']);
+		echo json_encode([
+			'error' => 'Autorisierung nicht moeglich, token:'.$token.' ist kein gueltiger token'
+		]);
 		exit();
 	}
 	
-	//	JWT ueberprufen
-	//	Neue Insanz der Klasse: JwtHandler
-	//	Konstruktoraufruf
+    /**
+	 * Prueft, ob die Token-Signatur gueltig ist und liest die Benutzer-ID aus.
+	 * 
+	 * @todo
+	 * Auslagern in ein separates Modul zur Wiederverwendung und besseren Strukturierung.
+	 *
+	 * @remarks
+	 * Nutzt die JwtHandler-Klasse:
+	 * 1. validiert den Token,
+	 * 2. extrahiert die user_id
+	 */
 	$jwt = new \Core\JwtHandler();
 	$userData = $jwt->validateToken($token);
 	$userId = $jwt->getUserIdFromToken($token);
 	
+	/*
+	 * Prueft, ob die Benutzerinformationen vorhanden sind.
+	 * Gibt bei fehlender Autorisierung einen Fehler zurueck.
+	 *
+	 * @todo
+     * Die Pruefung auf gueltige Benutzerinformationen inklusive Fehlerbehandlung
+	 * kann ausgelagert werden, diese wird auch an anderen Stellen benoetigt.
+	 * Ziel: zentrale Methode zur Autorisierungspruefung, die bei ungueltigem Benutzer
+	 * einheitlich mit Fehlercode und Nachricht reagiert.
+	 *
+	 * @todo
+	 * Die Logik der Fehlerbehandlung ist falsch.
+	 * Unbedingt anpassen.
+	 *
+	 * @remarks
+	 * Wenn userData null ist, kann nicht darauf zugegriffen werden.
+	 * Dies fuehrt zu unvorhersehbaren Problemen im Programmablauf.
+	 */
 	if($userData === null){
 		http_response_code(401);
-		echo json_encode(['error' => $userData['message']]);
+		echo json_encode([
+			'error' => $userData['message']
+		]);
 		exit();
 	}
 	
-	//	Nutzerdaten aus DB holen
-	//	Das koennte man doch aus auslagern, damit der Webserver
-	//	hierrauf keinen Zugriff gibt ueber public?
+	/**
+	 * Benutzerdaten aus der Datenbank abrufen.
+	 *
+	 * @todo Auslagern in eine Hilfsfunktion.
+	 */
 	$stmt = $pdo->prepare("select first_name, surname from users where id = ?");
 	$stmt->execute([$userId]);
 	$user = $stmt->fetch();
 	
+	/**
+	 * Antwortstruktur fuer Backend-Meldung.
+	 *
+	 * Erfolgsfall:
+	 * @return array{
+	 *   user_id: int,
+	 *   surname: string,
+	 *   first_name: string
+	 * }
+	 *
+	 * Fehlerfall:
+	 * @return array{
+	 *   error: string
+	 * }
+	 */
+	
+	/*
+	 * Sende Fehlermeldung, wenn Benutzer nicht gefunden.
+	 */
 	if(!$user){
 		http_response_code(404);
-		echo json_encode(['error' => 'Benutzer nicht gefunden']);
+		echo json_encode([
+			'error' => 'Benutzer nicht gefunden'
+		]);
 		exit();
 	}
 	
+	/*
+	 * Sende Benutzerinformationen an das Frontend.
+	 */
 	echo json_encode([
 		'user_id' => $userId,
 		'surname' => $user['surname'],


### PR DESCRIPTION
### Hintergrund

In unseren PHP-Dateien im Frontend gab es noch keine richtige Beschreibung, was die Dateien machen. Das macht es schwer, den Code zu verstehen oder später zu ändern. Mit diesem PR haben wir überall Kommentare eingefügt, die den Code erklären. Es wurde nichts am Verhalten geändert.

---

### Änderungen im Detail

- Kommentare (PHPDoc) in allen Frontend-PHP-Dateien ergänzt:
 - addUserTodo.php
 - deleteUserTodo.php
 - get_user_todos.php
 - login.php
 - register.php
 - toggleUserTodoStatus.php
 - user_info.php
- Beschreibung von möglichen Fehlern, Rückgaben und Aufgaben für später (@todo)
- Fehlercodes wie 400, 401, 405 wurden einheitlich dokumentiert

---

### Ziel / Zweck des PRs

- Der Code soll leichter zu verstehen sein
- Andere Entwickler sollen wissen, was jede Datei macht
- Vorbereitung für spätere Verbesserungen

---

### Testhinweise

- Keine Änderungen am Verhalten
- Alles sollte wie vorher funktionieren
- Kein Test nötig, nur Kommentare wurden ergänzt

---

### Hinweise für Reviewer

- Bitte prüfe nur die neuen Kommentare
- Der Code selbst bleibt gleich
- Fehler oder Wiederholungen im Code sind nur markiert, aber noch nicht geändert

---

### Folgeänderungen (optional)

- [ ] Wiederverwendbare Funktionen auslagern (z. B. für Token-Prüfung)
- [ ] Fehlerbehandlung vereinheitlichen