### PR TITLE
Feat/response status

### DIFF
--- a/projekt/src/shared/response/Response.php
+++ b/projekt/src/shared/response/Response.php
@@ -80,9 +80,10 @@
 		 *
 		 * @return void
 		 */
-		public static function status(string $message='OK', int $statusCode = 200){
+		public static function status(string $message='OK', bool $success = true, int $statusCode = 200){
 			http_response_code($statusCode);
 			echo(json_encode([
+				'success' => '$success',
 				'status' => $message,
 				'timestamp' => gmdate('c')
 			]));

--- a/projekt/src/shared/response/Response.php
+++ b/projekt/src/shared/response/Response.php
@@ -76,6 +76,7 @@
 		 * Kann z. B. fuer Health Checks oder Verfuegbarkeitspruefungen verwendet werden.
 		 *
 		 * @param string $message Statusinformation (Standard: "OK")
+		 * @param bool $success Gibt an, ob der Status als Erfolg gewertet wird
 		 * @param int $statusCode HTTP-Statuscode (Standard: 200)
 		 *
 		 * @return void


### PR DESCRIPTION
### Hintergrund

Die bestehende status()-Methode der Response-Klasse sollte erweitert werden, um flexibler auf verschiedene Statussituationen reagieren zu können.

---

### Änderungen im Detail

- Neues optionales Argument success ergänzt (bool)
- HTTP-Antwortstruktur angepasst: Gibt nun optional ein success-Feld zurück
- PHPDoc der Methode aktualisiert

---

### Ziel / Zweck des PRs

Die Methode status() soll auch einfache Statusmeldungen wie Erfolg/Misserfolg strukturiert zurückgeben können (z. B. für Health-Checks).

---

### Testhinweise

Die Methode Response::status() kann direkt aufgerufen werden.
Beispiel: Response::status('Datenbank erreichbar', 200, true);

---

### Hinweise für Reviewer

- Keine externen Abhängigkeiten oder Seiteneffekte.