### PR TITLE
fix(backend/shared/response): fix param in status-method

### DIFF
--- a/projekt/src/shared/response/Response.php
+++ b/projekt/src/shared/response/Response.php
@@ -84,7 +84,7 @@
 		public static function status(string $message='OK', bool $success = true, int $statusCode = 200){
 			http_response_code($statusCode);
 			echo(json_encode([
-				'success' => '$success',
+				'success' => $success,
 				'status' => $message,
 				'timestamp' => gmdate('c')
 			]));


### PR DESCRIPTION
### Hintergrund

Im Rückgabe-Array der status()-Methode wurde der success-Wert versehentlich als String statt als boolesche Variable zurückgegeben. Das wurde nun korrigiert.

---

### Änderungen im Detail

- Fehlerhafte Rückgabe success => '$success' durch korrekte success => $success ersetzt

---

### Ziel / Zweck des PRs

Sicherstellen, dass das Feld success im JSON korrekt als true oder false ausgegeben wird, nicht als String.

---

### Testhinweise

Aufruf von Response::status() testen und prüfen, ob "success": true bzw. "success": false korrekt im JSON erscheint.

---

### Hinweise für Reviewer

Kein Einfluss auf andere Funktionen. Nur ein Bugfix.