### PR TITLE
Feat/controller response debug

### DIFF
--- a/projekt/src/todo-new/controller/TodoController.php
+++ b/projekt/src/todo-new/controller/TodoController.php
@@ -15,7 +15,22 @@
 		 * Fuegt ein neues Todo hinzu.
 		 *
 		 * Erwartet im Body: {"title: "..."}
-		 * Gibt JSON-Antwort zurueck mit Erfolg oder Fehlermeldung.
+		 * Gibt eine strukturierte JSON-Antwort zurueck:
+		 * - Erfolg: Response::success([...])
+		 * - Fehler: Response::error(...) oder Response::debug(...)
+		 *
+		 * Hinweis zum Fehlerhandling:
+		 * Das zurueckgelieferte $result-Array kann je nach Quelle
+		 * folgende Form annehmen:
+		 *
+		 * - ['success' => true] -> Erfolgreich
+		 * - ['success' => false, 'error' => ...] -> Bekannte Fehler
+		 * - ['success' => false, 'error' => ..., 'source' => 'service']
+		 * - ['success' => false, 'error' => ..., 'debug' => [...], 'source' => 'repository']
+		 *
+		 * Bei debug-Faellen wird die gesamte $result-Struktur an
+		 * Response::debug uebergeben, um eine verschachtelte Darstellung
+		 * fuer die Analyse zu ermoeglichen.
 		 *
 		 * @return void
 		 */
@@ -42,8 +57,12 @@
 			$result = $service->addTodo($titleTodo);
 			
 			// Erfolg oder Fehler zurueckgeben
-			if($result['success']){
+			if($result['success'] === true){
 				Response::success($result, 201);
+			}elseif($result['success'] === false && ($result['source'] ?? '') === 'service'){
+				Response::debug('Service-Fehler', $result);
+			}elseif($result['success'] === false && ($result['source'] ?? '') === 'repository')){
+				Response::debug('Repository-Fehler', $result);
 			}else{
 				Response::error(($result['error'] ?? 'Unbekannter Fehler'), 500);
 			}

--- a/projekt/src/todo-new/repository/TodoRepository.php
+++ b/projekt/src/todo-new/repository/TodoRepository.php
@@ -25,7 +25,23 @@
 				throw new InvalidArgumentException('Title darf nicht länger als 255 Zeichen sein.');
 			}
 			
-			$stmt = $pdo->prepare("INSERT INTO todos (user_id, title) values (?, ?)");
-			return $stmt->execute([$userId, $title]);
+			try{
+				$stmt = $pdo->prepare("INSERT INTO todos (user_id, title) values (?, ?)");
+				return $stmt->execute([$userId, $title]);
+			}catch(PDOException $e){
+				/*
+				 * Gibt ein strukturiertes Fehler-Array mit Debug-Infos
+				 * zurueck (fuer Controller sichtbar)
+				 */
+				return [
+					'success' => false,
+					'error' => 'Fehler beim Hinzufuegen des Todos in die Datenbank.',
+					'debug' => [
+						'exception' => $e->getMessage(),
+						'trace' => $e->getTraceAsString()
+					],
+					'source' => 'repository'
+				];
+			}
 		}
 	}

--- a/projekt/src/todo-new/service/TodoService.php
+++ b/projekt/src/todo-new/service/TodoService.php
@@ -23,13 +23,17 @@
 				// Weitergabe an Repository
 				$success = $repository->insertTodo($userId, $title);
 				
-				if($success){
+				if(is_array($success) && ($success['success'] ?? false) === false){
+					return $success;
+				}else{
 					return ['success' => true];
-				} else {
-					return ['success' => false, 'error' => 'Einfuegen fehlgeschlagen'];
 				}
 			}catch(Exception $e){
-				return ['success' => false, 'error' => $e->getMessage()];
+				return [
+					'success' => false,
+					'error' => $e->getMessage(),
+					'source' => 'service'
+				];
 			}
 		}
 	}


### PR DESCRIPTION
### Hintergrund

Ziel dieses PRs ist es, die bestehende Fehlerbehandlung um strukturierte Debug-Ausgaben zu erweitern. Dafür soll Response::debug() im Controller verwendet werden, um im Entwicklungsmodus differenzierte Fehleranalysen zu ermöglichen.

---

### Änderungen im Detail

- Anpassung der Rückgabestruktur im Repository: Fehler werden nun als strukturierte Arrays inklusive debug- und source-Feld geliefert
- Erweiterung des Service: Fehlerarrays aus dem Repository werden direkt durchgereicht, eigene Fehler mit source ergänzt
- Umstellung des Controllers auf if/else-Logik zur Unterscheidung von Erfolg, Fehler und Debug-Ausgaben

---

### Ziel / Zweck des PRs

- Einheitliche Fehlerweitergabe bis zum Controller und gezielte Nutzung von Response::debug() bei unerwarteten Fehlern aus repository oder service. Damit sollen Fehlerquellen im Entwicklungsprozess klar identifizierbar sein.

---

### Testhinweise

- Simulierter Datenbankfehler: Response::debug mit voller Fehlerstruktur

---

### Hinweise für Reviewer

- Die Fehlerstruktur ist absichtlich tief verschachtelt, damit im Frontend differenziert ausgewertet werden kann
- Response::debug ist nur für Dev-Umgebungen vorgesehen