### PR TITLE
refactor(backend/todo-new/repository): add error handling for databas…

### DIFF
--- a/projekt/src/todo-new/repository/TodoRepository.php
+++ b/projekt/src/todo-new/repository/TodoRepository.php
@@ -27,7 +27,20 @@
 			
 			try{
 				$stmt = $pdo->prepare("INSERT INTO todos (user_id, title) values (?, ?)");
-				return $stmt->execute([$userId, $title]);
+				$dbResult = $stmt->execute([$userId, $title]);
+				if($dbResult){
+					return true;
+				}else{
+					return [
+						'success' => false,
+						'error' => 'INSERT fehlgeschlagen',
+						'debug' => [
+							'errorInfo' => $stmt->errorInfo()
+						],
+						'source' => 'todo-new/repository'
+					];
+				}
+				
 			}catch(PDOException $e){
 				/*
 				 * Gibt ein strukturiertes Fehler-Array mit Debug-Infos


### PR DESCRIPTION
### Hintergrund

Im Rahmen der Modularisierung und Vereinheitlichung der Fehlerstruktur wurde im TodoRepository das Datenbank-Fehlerhandling erweitert. Bisherige Rückgaben bei fehlgeschlagenem execute()-Aufruf oder PDO-Ausnahme wurden nicht differenziert behandelt.

---

### Änderungen im Detail

- Prüfung des Rückgabewerts von $stmt->execute(...)
- Strukturierte Fehlerantwort bei fehlgeschlagenem Insert

---

### Ziel / Zweck des PRs

Die Fehler im Repository sollen konsistent strukturiert zurückgegeben werden, damit der Controller je nach Fehlerquelle gezielt reagieren und Fehler an den Client weiterreichen kann.

---

### Hinweise für Reviewer

- Keine externen Abhängigkeiten. Logik nur lokal in TodoRepository::insertTodo.