### PR TITLE
Docs/backend return structur phpdoc

### DIFF
--- a/projekt/src/shared/response/Response.php
+++ b/projekt/src/shared/response/Response.php
@@ -7,12 +7,35 @@
 	namespace Shared\Response;
 	
 	/**
-	 * Stellt eine zentrale Antwortstruktur fuer API-Endpunkte bereit.
-	 * Ziel: Einheitliche JSON-Antworten im Erfolgs- und Fehlerfall.
+     * Standardisierte API-Antwortstruktur fuer alle HTTP-Responses im Projekt.
 	 *
-	 * @example
-	 *    Response::success(['todos' => $todos]);
-	 *    Response::error('Fehlende Eingabe', 400);
+	 * Erfolgreiche Antwort (Response::success()):
+	 * {
+	 *    "success" : true,
+	 *    "data": { ... }
+	 * }
+	 *
+	 * Validierungs- oder Clientfehler (Response::error()):
+	 * {
+	 *    "success": false,
+	 *    "message": "Fehlermeldung"
+	 * }
+	 *
+	 * Interner Fehler mit Debug-Daten (Response::debug()):
+	 * {
+	 *    "success": false,
+	 *    "message": "Fehlermeldung",
+	 *    "debug": { ... }
+	 * }
+	 *
+	 * Systemstatus (Response::status()):
+	 * {
+	 *    "success": true,
+	 *    "status": "OK",
+	 *    "timestamp": "yyyy-mm-dd-T-hh-mm-ss"
+	 * }
+	 *
+	 * @package Shared\Response
 	 */
 	Class Response{
 		/**

--- a/projekt/src/todo-new/controller/TodoController.php
+++ b/projekt/src/todo-new/controller/TodoController.php
@@ -14,25 +14,24 @@
 		/**
 		 * Fuegt ein neues Todo hinzu.
 		 *
-		 * Erwartet im Body: {"title: "..."}
-		 * Gibt eine strukturierte JSON-Antwort zurueck:
-		 * - Erfolg: Response::success([...])
-		 * - Fehler: Response::error(...) oder Response::debug(...)
+		 * Erwartet im HTTP-Body eine JSON-Struktur mit dem Feld "title".
+		 * Beispiel: { "title": "Einkaufen" }
 		 *
-		 * Hinweis zum Fehlerhandling:
-		 * Das zurueckgelieferte $result-Array kann je nach Quelle
-		 * folgende Form annehmen:
+		 * Die Methode verarbeitet die Anfrage, validiert Eingabedaten,
+		 * uebergibt den Titel an den Service und leitet das Ergebnis
+		 * an die passende Response-Methode weiter.
 		 *
-		 * - ['success' => true] -> Erfolgreich
-		 * - ['success' => false, 'error' => ...] -> Bekannte Fehler
-		 * - ['success' => false, 'error' => ..., 'source' => 'service']
-		 * - ['success' => false, 'error' => ..., 'debug' => [...], 'source' => 'repository']
+		 * Fehlerhafte oder unvollstaendige Eingaben werden direkt mit
+		 * Response::error() beantwortet.
 		 *
-		 * Bei debug-Faellen wird die gesamte $result-Struktur an
-		 * Response::debug uebergeben, um eine verschachtelte Darstellung
-		 * fuer die Analyse zu ermoeglichen.
+		 * Abhaengig von der Quelle des Fehlers nutzt der Controller:
+		 * - Response::success() bei Erfolg
+		 * - Response::debug() bei Service-/Repository-Fehlern
+		 * - Response::error() bei sonstigen Fehler
 		 *
-		 * @return void
+		 * @return
+		 * void Gibt direkt eine JSON-Antwort an den Client aus und beendet
+		 * die Ausfuehrung.
 		 */
 		 public function add(){
 			/*
@@ -57,6 +56,9 @@
 			$result = $service->addTodo($titleTodo);
 			
 			// Erfolg oder Fehler zurueckgeben
+			/**
+			 * @todo Bezeichnungen fuer das Feld: source in $result anpassen!!!
+			 */
 			if($result['success'] === true){
 				Response::success($result, 201);
 			}elseif($result['success'] === false && ($result['source'] ?? '') === 'service'){

--- a/projekt/src/todo-new/repository/TodoRepository.php
+++ b/projekt/src/todo-new/repository/TodoRepository.php
@@ -2,9 +2,35 @@
 	require_once __DIR__ . '/../../../bootstrap/init.php';
 	
 	/**
-	 * Repository-Klasse
+	 * Fuegt ein neues Todo fuer den angegebenen Benutzer hinzu.
 	 *
-	 * Verantwortlich fuer den Datenbankzugriff.
+	 * Bei erfolgreichem INSERT:
+	 *   return true
+	 *
+	 * Bei SQL-Ausfuehrungsfehler ohne Exception:
+	 * return [
+	 *    'success' => false,
+	 *    'INSERT fehlgeschlagen',
+	 *    'debug' => [
+	 *       'errorInfo' => [...PDO Fehlerinfo...]
+	 *    ],
+	 *    'source' => 'todo-new/repository'
+	 * ]
+	 *
+	 * Bei PDO-Exception (z.B. Verbindungsfehler):
+	 * return [
+	 *    'success' => false,
+	 *    'error' => 'Fehler beim Hinzufuegen des Todos in die Datenbank.',
+	 *    'debug' => [
+	 *       'exception' => 'Fehlermeldung',
+	 *       'trace' => 'Stacktrace'
+	 *    ],
+	 *    'source' => 'repository'
+	 * ]
+	 *
+	 * @param int $userId Benutzer-ID
+	 * @param string $title Titel des Todos
+	 * @return bool|array true bei Erfolg, sonst strukturierter Fehler
 	 */
 	class TodoRepository{
 		/**

--- a/projekt/src/todo-new/service/TodoService.php
+++ b/projekt/src/todo-new/service/TodoService.php
@@ -8,10 +8,25 @@
 	 */
 	class TodoService{
 		/**
-		 * Fuegt ein neues Todo hinzu.
+		 * Fuegt ein neues Todo hinzu und verarbeitet das Ergebnis des
+		 * Repositories.
+		 *
+		 * Erfolgreicher Eintrag:
+		 * return [
+		 *    'success' => true
+		 * ]
+		 *
+		 * Fehler im Service selbst (z. B. unerwartete Exception):
+		 * return [
+		 *    'success' => false,
+		 *    'error' => 'Fehlermeldung aus Exception'
+		 *    'source' => 'service'
+		 * ]
+		 *
+		 * Fehlerstruktur des Repositories wird unveraendert durchgereicht.
 		 *
 		 * @param string $title Der Titel des Todos.
-		 * @return array ['success' => bool, 'error' => string|null]
+		 * @return array Strukturierte Erfolgs- und Fehlermeldung
 		 */
 		public function addTodo(string $title): array{
 			$repository = new TodoRepository();


### PR DESCRIPTION
### Hintergrund

In diesem PR wurden die Rückgabestrukturen der Backend-Komponenten (Repository, Service, Controller sowie Response) umfassend mittels PHPDoc dokumentiert. Ziel ist es, die erwarteten Strukturen bei Erfolgs- und Fehlerfällen direkt ersichtlich zu machen, ohne die jeweilige Logik durchdringen zu müssen.

---

### Änderungen im Detail

- Dokumentation der Rückgabe in insertTodo() im TodoRepository
- Beschreibung der Struktur von addTodo() im TodoService
- Ergänzung zu Response-Verhalten in TodoController::add()
- Ausführliche Strukturbeschreibung in der Response-Klasse (success, error, debug, status)

---

### Ziel / Zweck des PRs

- Rückgabelogik an zentraler Stelle sichtbar machen
- Einheitliche Fehler- und Erfolgsbehandlung leichter nachvollziehbar
- Schnellere Einarbeitung und weniger Kontextwechsel beim Lesen des Codes

---

### Testhinweise

- Es wurden ausschließlich Kommentare ergänzt – keine Laufzeitveränderungen
- Keine Tests notwendig

---

### Hinweise für Reviewer

- Fokus auf Vollständigkeit und Klarheit der PHPDoc-Kommentare
- Konsistenz zur tatsächlichen Implementierung beachten