### PR TITLE
Refactor/service pass userid to repository

### DIFF
--- a/projekt/src/todo-new/controller/TodoController.php
+++ b/projekt/src/todo-new/controller/TodoController.php
@@ -52,7 +52,7 @@
 			
 			// Weitergabe an Service
 			$service = new TodoService();
-			$result = $service->addTodo($titleTodo);
+			$result = $service->addTodo($titleTodo, $userId);
 			
 			// Erfolg oder Fehler zurueckgeben
 			/**

--- a/projekt/src/todo-new/service/TodoService.php
+++ b/projekt/src/todo-new/service/TodoService.php
@@ -8,8 +8,8 @@
 	 */
 	class TodoService{
 		/**
-		 * Fuegt ein neues Todo hinzu und verarbeitet das Ergebnis des
-		 * Repositories.
+		 * Fuegt ein neues Todo fuer einen bestimmten Benutzer hinzu
+		 * und verarbeitet das Ergebnis des Repositories.
 		 *
 		 * Erfolgreicher Eintrag:
 		 * return [
@@ -26,15 +26,13 @@
 		 * Fehlerstruktur des Repositories wird unveraendert durchgereicht.
 		 *
 		 * @param string $title Der Titel des Todos.
+		 * @param int $userId Die ID des angemeldeten Benutzers.
 		 * @return array Strukturierte Erfolgs- und Fehlermeldung
 		 */
-		public function addTodo(string $title): array{
+		public function addTodo(string $title, int $userId): array{
 			$repository = new TodoRepository();
 			
 			try{
-				// Beispiel-ID fuer Benutzer, spaeter durch echtes Auth-System ersetzen
-				$userId = 1;
-				
 				// Weitergabe an Repository
 				$success = $repository->insertTodo($userId, $title);
 				


### PR DESCRIPTION
### Hintergrund

Die bisherige addTodo-Methode im Service nutzte eine fest kodierte Benutzer-ID. Im Zuge der Middleware-Einführung (insbesondere AuthMiddleware) steht nun die echte userId aus dem Token zur Verfügung. Diese soll nun dynamisch übergeben werden.

---

### Änderungen im Detail

- Methode addTodo(string $title) -> addTodo(string $title, int $userId)
- PHPDoc der Methode überarbeitet
- Controller-Logik angepasst:
  - AuthMiddleware::handle() liefert die userId
  - Diese wird an addTodo übergeben
  - Vorheriger fest kodierter Wert entfällt

---

### Ziel / Zweck des PRs

Ermöglichen einer echten Benutzerbindung beim Anlegen von Todos, basierend auf dem JWT. Statt statischem Dummy-Wert wird die tatsächliche userId verwendet.

---

### Testhinweise

- Bei ungültigem Token sollte der Zugriff wie gehabt blockiert werden

---

### Hinweise für Reviewer

- Die Middleware liefert nun userId direkt an den Controller zurück
- Statischer Wert entfernt wurde entfernt.